### PR TITLE
Explicit message when wait for user input

### DIFF
--- a/install
+++ b/install
@@ -54,7 +54,7 @@ end
 
 def wait_for_user
   puts
-  puts "Press RETURN to continue or any other key to abort"
+  puts "Press ENTER to continue or any other key to abort"
   c = getc
   # we test for \r and \n because some stuff does \r instead
   abort unless c == 13 or c == 10


### PR DESCRIPTION
`Press RETURN to continue...` is not explicit on what needs to be done. We guess it's about the enter key, but it's more natural to read `Press ENTER to continue...` IMHO