### PR TITLE
Don't tell new users to run brew doctor

### DIFF
--- a/install
+++ b/install
@@ -219,5 +219,4 @@ else
   puts "Install #{Tty.white}Xcode#{Tty.reset}: https://developer.apple.com/xcode" unless File.exist? "/usr/bin/cc"
 end
 
-puts "Run `brew doctor` #{Tty.white}before#{Tty.reset} you install anything"
 puts "Run `brew help` to get started"


### PR DESCRIPTION
Running `brew doctor` before a user runs into trouble seems to inspire anxiety uncorrelated to the magnitude of the problems encountered, which has gotten worse as `brew doctor` has gotten more verbose (and more helpful!). Telling users to run `doctor` out of the gate conflicts with the spirit of the message in the `doctor` output telling users not to worry about reports until they've actually run into trouble. I think removing this advice will help improve the new user experience.