### PR TITLE
Default to shallow clone

### DIFF
--- a/install
+++ b/install
@@ -192,7 +192,7 @@ Dir.chdir HOMEBREW_PREFIX do
     system git, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"
 
     args = git, "fetch", "origin", "master:refs/remotes/origin/master", "-n"
-    args << "--depth=1" if ARGV.include? "--fast"
+    args << "--depth=1" unless ARGV.include?("--full") || !ENV["HOMEBREW_DEVELOPER"].nil?
     system(*args)
 
     system git, "reset", "--hard", "origin/master"


### PR DESCRIPTION
Since most of users wouldn't care about the history, let's default
to shallow clone unless `--full` is passed.

Related issues:

* https://github.com/Homebrew/homebrew/issues/37592
* https://github.com/Homebrew/homebrew/pull/38268

cc @mikemcquaid