### PR TITLE
install: Fix stray non-breaking space

### DIFF
--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
 # This script installs to /usr/local only. To install elsewhere you can just
-# untar https://github.com/Homebrew/homebrew/tarball/master anywhere you like or
+# untar https://github.com/Homebrew/homebrew/tarball/master anywhere you like or
 # change the value of HOMEBREW_PREFIX.
 HOMEBREW_PREFIX = '/usr/local'
 HOMEBREW_CACHE = '/Library/Caches/Homebrew'


### PR DESCRIPTION
Somehow a regular space got turned into a non-breaking space.