### PR TITLE
Allow parameterization of standard locations like HOMEBREW_PREFIX

### DIFF
--- a/install
+++ b/install
@@ -1,10 +1,10 @@
 #!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
 # This script installs to /usr/local only. To install elsewhere you can just
 # untar https://github.com/Homebrew/homebrew/tarball/master anywhere you like or
-# change the value of HOMEBREW_PREFIX.
-HOMEBREW_PREFIX = '/usr/local'
-HOMEBREW_CACHE = '/Library/Caches/Homebrew'
-HOMEBREW_REPO = 'https://github.com/Homebrew/homebrew'
+# provide a HOMEBREW_PREFIX environment variable.
+HOMEBREW_PREFIX = ENV.fetch('HOMEBREW_PREFIX') { '/usr/local' }
+HOMEBREW_CACHE =  ENV.fetch('HOMEBREW_CACHE')  { '/Library/Caches/Homebrew' }
+HOMEBREW_REPO =   ENV.fetch('HOMEBREW_REPO')   { 'https://github.com/Homebrew/homebrew' }
 
 module Tty extend self
   def blue; bold 34; end


### PR DESCRIPTION
This pull request allows constants like `HOMEBREW_PREFIX` to be overridden via environment variables. This makes it easier to install Homebrew to a non-standard location — for example, a user-specific installation in `$HOME/.brew` — while reusing the standard install script.

```bash
HOMEBREW_PREFIX=$HOME/.brew \
ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
```