### PR TITLE
removed incorrect comment (incorrect since commit 8c6a0ff removed -k flag)

### DIFF
--- a/install
+++ b/install
@@ -206,7 +206,6 @@ Dir.chdir HOMEBREW_PREFIX do
   else
     # -m to stop tar erroring out if it can't modify the mtime for root owned directories
     # pipefail to cause the exit status from curl to propogate if it fails
-    # we use -k for curl because Leopard has a bunch of bad SSL certificates
     curl_flags = "fsSL"
     system "/bin/bash -o pipefail -c '/usr/bin/curl -#{curl_flags} #{HOMEBREW_REPO}/tarball/master | /usr/bin/tar xz -m --strip 1'"
   end


### PR DESCRIPTION
Commit 8c6a0ff neglected to delete a comment line when it removed the -k flag used for Leopard. My comment corrects this.