### PR TITLE
install: chown as user.

### DIFF
--- a/install
+++ b/install
@@ -100,6 +100,10 @@ def chmod?(d)
   File.directory?(d) && !(File.readable?(d) && File.writable?(d) && File.executable?(d))
 end
 
+def chown?(d)
+  !File.owned?(d)
+end
+
 def chgrp?(d)
   !File.grpowned?(d)
 end
@@ -157,11 +161,16 @@ chmods = %w( . bin etc include lib lib/pkgconfig Library sbin share var var/log 
              share/man/man5 share/man/man6 share/man/man7 share/man/man8
              share/info share/doc share/aclocal ).
              map { |d| File.join(HOMEBREW_PREFIX, d) }.select { |d| chmod?(d) }
+chowns = chmods.select { |d| chown?(d) }
 chgrps = chmods.select { |d| chgrp?(d) }
 
 unless chmods.empty?
   ohai "The following directories will be made group writable:"
   puts(*chmods)
+end
+unless chowns.empty?
+  ohai "The following directories will have their owner set to #{Tty.underline 39}#{ENV['USER']}#{Tty.reset}:"
+  puts(*chowns)
 end
 unless chgrps.empty?
   ohai "The following directories will have their group set to #{Tty.underline 39}admin#{Tty.reset}:"
@@ -172,16 +181,19 @@ wait_for_user if STDIN.tty?
 
 if File.directory? HOMEBREW_PREFIX
   sudo "/bin/chmod", "g+rwx", *chmods unless chmods.empty?
+  sudo "/usr/sbin/chown", ENV['USER'], *chowns unless chowns.empty?
   sudo "/usr/bin/chgrp", "admin", *chgrps unless chgrps.empty?
 else
   sudo "/bin/mkdir", HOMEBREW_PREFIX
   sudo "/bin/chmod", "g+rwx", HOMEBREW_PREFIX
   # the group is set to wheel by default for some reason
-  sudo "/usr/bin/chgrp", "admin", HOMEBREW_PREFIX
+  sudo "/usr/sbin/chown", "#{ENV['USER']}:admin", HOMEBREW_PREFIX
 end
 
 sudo "/bin/mkdir", HOMEBREW_CACHE unless File.directory? HOMEBREW_CACHE
 sudo "/bin/chmod", "g+rwx", HOMEBREW_CACHE if chmod? HOMEBREW_CACHE
+sudo "/usr/sbin/chown", ENV['USER'], HOMEBREW_CACHE if chown? HOMEBREW_CACHE
+sudo "/usr/bin/chgrp", "admin", HOMEBREW_CACHE if chgrp? HOMEBREW_CACHE
 
 if macos_version >= "10.9"
   developer_dir = `/usr/bin/xcode-select -print-path 2>/dev/null`.chomp


### PR DESCRIPTION
We've been trying to avoid doing this for a while but it seems sensible to just do this by default considering how often we're recommending users do it.

Closes https://github.com/Homebrew/install/issues/21.

CC @Homebrew/owners 