### PR TITLE
Allowing HOMEBREW_PREFIX to be set by an environment variable.

### DIFF
--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 # This script installs to /usr/local only. To install elsewhere you can just
 # untar https://github.com/Homebrew/homebrew/tarball/master anywhere you like or
 # change the value of HOMEBREW_PREFIX.
-HOMEBREW_PREFIX = '/usr/local'
+HOMEBREW_PREFIX = ENV.fetch('HOMEBREW_PREFIX', '/usr/local')
 HOMEBREW_CACHE = '/Library/Caches/Homebrew'
 HOMEBREW_REPO = 'https://github.com/Homebrew/homebrew'
 


### PR DESCRIPTION
With this change Homebrew can be installed into a directory other
than /usr/local by running the installer with this command:
```
env HOMEBREW_PREFIX=/some/other/directory ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
```

Given the changes in OSX El Capitan it now seems desirable to install Homebrew in a location that is not under /usr.  This change would allow El Capitan users to specify a location other than /usr/local for the HOMEBREW_PREFIX without downloading the installer and modifying it.