### PR TITLE
Save sandbox abort test from greedy heredoc

### DIFF
--- a/install
+++ b/install
@@ -148,8 +148,7 @@ Xcode.app or running:
     sudo xcodebuild -license
 EOABORT
 sandbox_paths_file = "/System/Library/Sandbox/Compatibility.bundle/Contents/Resources/paths"
-abort <<-EOABORT if !File.directory?(HOMEBREW_PREFIX) && macos_version >= "10.11" \
-  && !(File.exist?(sandbox_paths_file) && IO.read(sandbox_paths_file).include?("/usr/local\n"))
+abort <<-EOABORT if !File.directory?(HOMEBREW_PREFIX) && macos_version >= "10.11" && !(File.exist?(sandbox_paths_file) && IO.read(sandbox_paths_file).include?("/usr/local\n"))
 Your OS X 10.11 install requires an additional step to write into #{HOMEBREW_PREFIX}.
 Please follow the steps described here and then run the install script again:
   https://git.io/vnC7w


### PR DESCRIPTION
Heredocs begin immediately on the next line, which means that the
expression containing <<-EOABORT and the modifier-if must not spill onto
the next line even if '\' is used.