### PR TITLE
Correctly determine membership in the 'admin' group when 'group' only

### DIFF
--- a/install
+++ b/install
@@ -119,7 +119,7 @@ Dir.chdir "/usr"
 abort "See Linuxbrew: http://brew.sh/linuxbrew/" if /linux/i === RUBY_PLATFORM
 abort "MacOS too old, see: https://github.com/mistydemeo/tigerbrew" if macos_version < "10.6"
 abort "Don't run this as root!" if Process.uid == 0
-abort <<-EOABORT unless `groups`.split.include? "admin"
+abort <<-EOABORT unless `dsmemberutil checkmembership -U #{ENV['USER']} -G admin`.include? "user is a member"
 This script requires the user #{ENV['USER']} to be an Administrator. If this
 sucks for you then you can install Homebrew in your home directory or however
 you please; please refer to our homepage. If you still want to use this script


### PR DESCRIPTION
When a computer is 'managed', it won't return the local groups, but rather the organization's groups:
```
$ groups
COMPANY\Domain Users COMPANY\Document Managers COMPANY\Wireless
```

Which will cause the installer to fail, because it can't find 'admin'
```
$ ruby install
This script requires the user swalsh to be an Administrator. If this
sucks for you then you can install Homebrew in your home directory or however
you please; please refer to our homepage. If you still want to use this script
set your user to be an Administrator in System Preferences or `su' to a
non-root user with Administrator privileges.
```

The OSX-y way of doing this is 'dsmemberutil':
```
$ dsmemberutil checkmembership -U swalsh -G admin
user is a member of the group
```