### PR TITLE
Enable headless/non-interactive install of Command Line Tools.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
 # This ensures the Command Line Tool install functionality is tested.
 before_script:
   - sudo rm -rf /Applications/Xcode.app /Library/Developer/CommandLineTools
+  - sudo pkgutil --forget com.apple.pkg.CLTools_Executables
 
 script:
   - ./uninstall -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
       osx_image: beta-xcode6.2
       rvm: system
 
+# Remove Xcode and CommandLineTools included in default OS X image.
+# This ensures the Command Line Tool install functionality is tested.
+before_script:
+  - sudo rm -rf /Applications/Xcode.app /Library/Developer/CommandLineTools
+
 script:
   - ./uninstall -d
   - ./uninstall -f

--- a/install
+++ b/install
@@ -201,10 +201,12 @@ sudo "/usr/bin/chgrp", "admin", HOMEBREW_CACHE if chgrp? HOMEBREW_CACHE
 if macos_version >= "10.9"
   developer_dir = `/usr/bin/xcode-select -print-path 2>/dev/null`.chomp
   if developer_dir.empty? || !File.exist?("#{developer_dir}/usr/bin/git")
-    ohai "Installing the Command Line Tools (expect a GUI popup):"
-    sudo "/usr/bin/xcode-select", "--install"
-    puts "Press any key when the installation has completed."
-    getc
+    ohai "Searching online for the Command Line Tools"
+    # This temporary file prompts software update to list the Command Line Tools
+    `touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress`
+    clt = `softwareupdate -l | grep "* Command Line Tools" | sed 's/^.*\\(Command Line Tools.*\\)/\\1/'`.chomp
+    ohai "Installing #{clt}"
+    `softwareupdate -i "#{clt}"`
   end
 end
 

--- a/install
+++ b/install
@@ -215,16 +215,19 @@ if should_install_command_line_tools
   clt_label = `softwareupdate -l | grep -B 1 -E "Command Line (Developer|Tools)" | awk -F"*" '/^ +\\*/ {print $2}' | sed 's/^ *//' | head -n1`.chomp
   ohai "Installing #{clt_label}"
   sudo "/usr/sbin/softwareupdate", "-i", clt_label
-  sudo "/bin/rm", clt_placeholder
+  sudo "/bin/rm", "-f", clt_placeholder
 end
 
 # Headless install may have failed, so fallback to original 'xcode-select' method
 if should_install_command_line_tools
-  ohai "Headless installation of Command Line Tools has failed"
-  ohai "Installing the Command Line Tools (expect a GUI popup):"
-  sudo "/usr/bin/xcode-select", "--install"
-  puts "Press any key when the installation has completed."
-  getc
+  if STDIN.tty?
+    ohai "Installing the Command Line Tools (expect a GUI popup):"
+    sudo "/usr/bin/xcode-select", "--install"
+    puts "Press any key when the installation has completed."
+    getc
+  else
+    abort "Unable to proceed with manual Command Line Tools install without user input."
+  end
 end
 
 ohai "Downloading and installing Homebrew..."

--- a/install
+++ b/install
@@ -77,13 +77,10 @@ def macos_version
   @macos_version ||= Version.new(`/usr/bin/sw_vers -productVersion`.chomp[/10\.\d+/])
 end
 
-def should_install_command_line_tools
-  if macos_version >= "10.9"
-    developer_dir = `/usr/bin/xcode-select -print-path 2>/dev/null`.chomp
-    return developer_dir.empty? || !File.exist?("#{developer_dir}/usr/bin/git")
-  else
-    return false
-  end
+def should_install_command_line_tools?
+  return false if macos_version < "10.9"
+  developer_dir = `/usr/bin/xcode-select -print-path 2>/dev/null`.chomp
+  developer_dir.empty? || !File.exist?("#{developer_dir}/usr/bin/git")
 end
 
 def git
@@ -207,7 +204,7 @@ sudo "/bin/chmod", "g+rwx", HOMEBREW_CACHE if chmod? HOMEBREW_CACHE
 sudo "/usr/sbin/chown", ENV['USER'], HOMEBREW_CACHE if chown? HOMEBREW_CACHE
 sudo "/usr/bin/chgrp", "admin", HOMEBREW_CACHE if chgrp? HOMEBREW_CACHE
 
-if should_install_command_line_tools
+if should_install_command_line_tools?
   ohai "Searching online for the Command Line Tools"
   # This temporary file prompts the 'softwareupdate' utility to list the Command Line Tools
   clt_placeholder = "/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
@@ -219,14 +216,14 @@ if should_install_command_line_tools
 end
 
 # Headless install may have failed, so fallback to original 'xcode-select' method
-if should_install_command_line_tools
+if should_install_command_line_tools?
   if STDIN.tty?
     ohai "Installing the Command Line Tools (expect a GUI popup):"
     sudo "/usr/bin/xcode-select", "--install"
     puts "Press any key when the installation has completed."
     getc
   else
-    abort "Unable to proceed with manual Command Line Tools install without user input."
+    abort "Error: Cannot proceed with manual Command Line Tools install without user input!"
   end
 end
 

--- a/install
+++ b/install
@@ -77,6 +77,15 @@ def macos_version
   @macos_version ||= Version.new(`/usr/bin/sw_vers -productVersion`.chomp[/10\.\d+/])
 end
 
+def should_install_command_line_tools
+  if macos_version >= "10.9"
+    developer_dir = `/usr/bin/xcode-select -print-path 2>/dev/null`.chomp
+    return developer_dir.empty? || !File.exist?("#{developer_dir}/usr/bin/git")
+  else
+    return false
+  end
+end
+
 def git
   @git ||= if ENV['GIT'] and File.executable? ENV['GIT']
     ENV['GIT']
@@ -198,16 +207,24 @@ sudo "/bin/chmod", "g+rwx", HOMEBREW_CACHE if chmod? HOMEBREW_CACHE
 sudo "/usr/sbin/chown", ENV['USER'], HOMEBREW_CACHE if chown? HOMEBREW_CACHE
 sudo "/usr/bin/chgrp", "admin", HOMEBREW_CACHE if chgrp? HOMEBREW_CACHE
 
-if macos_version >= "10.9"
-  developer_dir = `/usr/bin/xcode-select -print-path 2>/dev/null`.chomp
-  if developer_dir.empty? || !File.exist?("#{developer_dir}/usr/bin/git")
-    ohai "Searching online for the Command Line Tools"
-    # This temporary file prompts software update to list the Command Line Tools
-    `touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress`
-    clt = `softwareupdate -l | grep "* Command Line Tools" | sed 's/^.*\\(Command Line Tools.*\\)/\\1/'`.chomp
-    ohai "Installing #{clt}"
-    `softwareupdate -i "#{clt}"`
-  end
+if should_install_command_line_tools
+  ohai "Searching online for the Command Line Tools"
+  # This temporary file prompts the 'softwareupdate' utility to list the Command Line Tools
+  clt_placeholder = "/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
+  sudo "/usr/bin/touch", clt_placeholder
+  clt_label = `softwareupdate -l | grep -B 1 -E "Command Line (Developer|Tools)" | awk -F"*" '/^ +\\*/ {print $2}' | sed 's/^ *//' | head -n1`.chomp
+  ohai "Installing #{clt_label}"
+  sudo "/usr/sbin/softwareupdate", "-i", clt_label
+  sudo "/bin/rm", clt_placeholder
+end
+
+# Headless install may have failed, so fallback to original 'xcode-select' method
+if should_install_command_line_tools
+  ohai "Headless installation of Command Line Tools has failed"
+  ohai "Installing the Command Line Tools (expect a GUI popup):"
+  sudo "/usr/bin/xcode-select", "--install"
+  puts "Press any key when the installation has completed."
+  getc
 end
 
 ohai "Downloading and installing Homebrew..."


### PR DESCRIPTION
It bugged me a little there's just this one GUI interaction required to install brew on a newly installed machine. By creating the temporary file ```/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress```, you can instead use ```softwareupdate``` to download without any interaction required.