### PR TITLE
install: abort if active dev dir set but missing

### DIFF
--- a/install
+++ b/install
@@ -153,6 +153,9 @@ Before running the installer again please agree to the license by opening
 Xcode.app or running:
     sudo xcodebuild -license
 EOABORT
+abort <<-EOABORT if `/usr/bin/xcode-select -print-path 2>/dev/null` != `/usr/bin/xcrun /usr/bin/xcode-select -print-path 2>/dev/null`
+#{`xcrun xcode-select`}
+EOABORT
 
 ohai "This script will install:"
 puts "#{HOMEBREW_PREFIX}/bin/brew"


### PR DESCRIPTION
(A) When the active developer dir is unset stdout will be
  `xcode-select --print-path`: empty
  `xcrun xcode-select --print-path`: empty

(B) When the active developer dir is set but missing stdout will be
  `xcode-select --print-path`: the path that was set
  `xcrun xcode-select --print-path`: empty

(C) When the active developer dir is set and not missing stdout will be
  `xcode-select --print-path`: the path that was set
  `xcrun xcode-select --print-path`: the path that was set

We want to fail on (B) only, so check for equality between the stdout of
`xcode-select --print-path` and `xcrun xcode-select --print-path`

This will not detect when the desired active developer directory is
a renamed Xcode.app but the CLT is being used as a fallback.