### PR TITLE
Added shell completion script paths to chmods/chowns/chgrps array.

### DIFF
--- a/install
+++ b/install
@@ -162,10 +162,10 @@ puts "#{HOMEBREW_PREFIX}/share/man/man1/brew.1"
 puts "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_brew"
 puts "#{HOMEBREW_PREFIX}/etc/bash_completion.d/brew"
 
-chmods = %w( . bin etc include lib lib/pkgconfig Library sbin share var var/log share/locale share/man
+chmods = %w( . bin etc etc/bash_completion.d include lib lib/pkgconfig Library sbin share var var/log share/locale share/man
              share/man/man1 share/man/man2 share/man/man3 share/man/man4
              share/man/man5 share/man/man6 share/man/man7 share/man/man8
-             share/info share/doc share/aclocal ).
+             share/info share/doc share/aclocal share/zsh share/zsh/site-functions ).
              map { |d| File.join(HOMEBREW_PREFIX, d) }.select { |d| chmod?(d) }
 chowns = chmods.select { |d| chown?(d) }
 chgrps = chmods.select { |d| chgrp?(d) }


### PR DESCRIPTION
My proposed fix for issue #39, where the destination directories for the shell completion scripts do not have their permissions modified for user level access during the installation process, as with the other install directories.