### PR TITLE
Fix problem when user name has white space in name like 'jurasek pavel'

### DIFF
--- a/install
+++ b/install
@@ -125,7 +125,7 @@ Dir.chdir "/usr"
 abort "See Linuxbrew: http://linuxbrew.sh/" if /linux/i === RUBY_PLATFORM
 abort "MacOS too old, see: https://github.com/mistydemeo/tigerbrew" if macos_version < "10.6"
 abort "Don't run this as root!" if Process.uid == 0
-abort <<-EOABORT unless `dsmemberutil checkmembership -U #{ENV['USER']} -G admin`.include? "user is a member"
+abort <<-EOABORT unless `dsmemberutil checkmembership -U "#{ENV['USER']}" -G admin`.include? "user is a member"
 This script requires the user #{ENV['USER']} to be an Administrator. If this
 sucks for you then you can install Homebrew in your home directory or however
 you please; please refer to our homepage. If you still want to use this script


### PR DESCRIPTION
This PR fix issues when installer return non-valid result for valid username :).

**Sympton:**
The user jurasek cannot be found
There was an unknown error.
This script requires the user jurasek pavel to be an Administrator. If this
sucks for you then you can install Homebrew in your home directory or however
you please; please refer to our homepage. If you still want to use this script
set your user to be an Administrator in System Preferences or `su' to a
non-root user with Administrator privileges.

**Investigation**
DVG-C02RG33FG:install jurasek pavel$ echo $USER
jurasek pavel

as you can see $USER need to be skipped in installer file.