### PR TITLE
Add HOMEBREW_REPOSITORY variable.

### DIFF
--- a/install
+++ b/install
@@ -3,6 +3,7 @@
 # untar https://github.com/Homebrew/brew/tarball/master anywhere you like or
 # change the value of HOMEBREW_PREFIX.
 HOMEBREW_PREFIX = "/usr/local".freeze
+HOMEBREW_REPOSITORY = HOMEBREW_PREFIX
 HOMEBREW_CACHE = "#{ENV["HOME"]}/Library/Caches/Homebrew".freeze
 BREW_REPO = "https://github.com/Homebrew/brew".freeze
 CORE_TAP_REPO = "https://github.com/Homebrew/homebrew-core".freeze
@@ -137,7 +138,7 @@ set your user to be an Administrator in System Preferences or `su' to a
 non-root user with Administrator privileges.
 EOABORT
 contents = Dir.glob(HOMEBREW_PREFIX+"*/{*,.git*}").join(" ").gsub!(%r{#{HOMEBREW_PREFIX}/}, "")
-abort <<-EOABORT unless Dir["#{HOMEBREW_PREFIX}/.git/*"].empty?
+abort <<-EOABORT unless Dir["{#{HOMEBREW_PREFIX},#{HOMEBREW_REPOSITORY}}/.git/*"].empty?
 It appears Homebrew is already installed. If your intent is to reinstall you
 should do the following before running this installer again:
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
@@ -154,11 +155,11 @@ EOABORT
 
 ohai "This script will install:"
 puts "#{HOMEBREW_PREFIX}/bin/brew"
-puts "#{HOMEBREW_PREFIX}/Library/..."
 puts "#{HOMEBREW_PREFIX}/share/doc/homebrew"
 puts "#{HOMEBREW_PREFIX}/share/man/man1/brew.1"
 puts "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_brew"
 puts "#{HOMEBREW_PREFIX}/etc/bash_completion.d/brew"
+puts "#{HOMEBREW_REPOSITORY}/Library/..."
 
 chmods = %w( . bin etc etc/bash_completion.d include lib lib/pkgconfig Library sbin share var var/log share/locale share/man
              share/man/man1 share/man/man2 share/man/man3 share/man/man4
@@ -232,7 +233,7 @@ Xcode.app or running:
 EOABORT
 
 ohai "Downloading and installing Homebrew..."
-Dir.chdir HOMEBREW_PREFIX do
+Dir.chdir HOMEBREW_REPOSITORY do
   if git
     # we do it in four steps to avoid merge errors when reinstalling
     system git, "init", "-q"
@@ -284,7 +285,7 @@ ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
 puts "Read the analytics documentation (and how to opt-out) here:"
 puts "  https://git.io/brew-analytics"
 if git
-  Dir.chdir HOMEBREW_PREFIX do
+  Dir.chdir HOMEBREW_REPOSITORY do
     system git, "config", "--local", "--replace-all", "homebrew.analyticsmessage", "true"
   end
 end


### PR DESCRIPTION
This is currently just set to HOMEBREW_PREFIX but may not be in future.
Use it consistently to ensure that we don’t assume `.git` is in the HOMEBREW_PREFIX.