### PR TITLE
install: restore more group chmods.

### DIFF
--- a/install
+++ b/install
@@ -163,7 +163,11 @@ if git
 end
 puts "#{HOMEBREW_REPOSITORY}"
 
-group_chmods = %w( bin etc Frameworks include lib sbin share var ).
+group_chmods = %w( bin etc Frameworks include lib sbin share var
+                   etc/bash_completion.d lib/pkgconfig var/log
+                   share/aclocal share/doc share/info share/locale share/man
+                   share/man/man1 share/man/man2 share/man/man3 share/man/man4
+                   share/man/man5 share/man/man6 share/man/man7 share/man/man8).
                    map { |d| File.join(HOMEBREW_PREFIX, d) }.select { |d| chmod?(d) }
 # zsh refuses to read from these directories if group writable
 zsh_dirs = %w( share/zsh share/zsh/site-functions )


### PR DESCRIPTION
Handle the case where users already have stuff there before installing Homebrew.

Fixes https://github.com/Homebrew/brew/issues/945