### PR TITLE
install: don't check for git early.

### DIFF
--- a/install
+++ b/install
@@ -155,12 +155,10 @@ EOABORT
 
 ohai "This script will install:"
 puts "#{HOMEBREW_PREFIX}/bin/brew"
-if git
-  puts "#{HOMEBREW_PREFIX}/share/doc/homebrew"
-  puts "#{HOMEBREW_PREFIX}/share/man/man1/brew.1"
-  puts "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_brew"
-  puts "#{HOMEBREW_PREFIX}/etc/bash_completion.d/brew"
-end
+puts "#{HOMEBREW_PREFIX}/share/doc/homebrew"
+puts "#{HOMEBREW_PREFIX}/share/man/man1/brew.1"
+puts "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_brew"
+puts "#{HOMEBREW_PREFIX}/etc/bash_completion.d/brew"
 puts "#{HOMEBREW_REPOSITORY}"
 
 group_chmods = %w( bin etc Frameworks include lib sbin share var ).


### PR DESCRIPTION
Otherwise this causes the CLT to try and install which preempts our nice messaging.