### PR TITLE
Improve based on user failures and repo migration.

### DIFF
--- a/install
+++ b/install
@@ -137,13 +137,6 @@ you please; please refer to our homepage. If you still want to use this script
 set your user to be an Administrator in System Preferences or `su' to a
 non-root user with Administrator privileges.
 EOABORT
-contents = Dir.glob(HOMEBREW_PREFIX+"*/{*,.git*}").join(" ").gsub!(%r{#{HOMEBREW_PREFIX}/}, "")
-abort <<-EOABORT unless Dir["{#{HOMEBREW_PREFIX},#{HOMEBREW_REPOSITORY}}/.git/*"].empty?
-It appears Homebrew is already installed. If your intent is to reinstall you
-should do the following before running this installer again:
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
-The current contents of #{HOMEBREW_PREFIX} are #{contents}
-EOABORT
 # Tests will fail if the prefix exists, but we don't have execution
 # permissions. Abort in this case.
 abort <<-EOABORT if File.directory? HOMEBREW_PREFIX and not File.executable? HOMEBREW_PREFIX
@@ -276,8 +269,6 @@ Dir.chdir HOMEBREW_REPOSITORY do
 
     system "ln", "-sf", "#{HOMEBREW_REPOSITORY}/bin/brew", "#{HOMEBREW_PREFIX}/bin/brew"
 
-    system "#{HOMEBREW_PREFIX}/bin/brew", "tap", "homebrew/core"
-
     system "#{HOMEBREW_PREFIX}/bin/brew", "update", "--force"
   else
     # -m to stop tar erroring out if it can't modify the mtime for root owned directories
@@ -292,6 +283,11 @@ Dir.chdir HOMEBREW_REPOSITORY do
     Dir.chdir core_tap do
       system "/bin/bash -o pipefail -c '/usr/bin/curl -#{curl_flags} #{CORE_TAP_REPO}/tarball/master | /usr/bin/tar xz -m --strip 1'"
     end
+
+    # Shown by `brew update` in above block.
+    ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
+    puts "Read the analytics documentation (and how to opt-out) here:"
+    puts "  https://git.io/brew-analytics"
   end
 end
 
@@ -310,20 +306,16 @@ end
 
 puts "Run `brew help` to get started"
 puts "Further documentation: https://git.io/brew-docs"
-ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
-puts "Read the analytics documentation (and how to opt-out) here:"
-puts "  https://git.io/brew-analytics"
+
 if git
   Dir.chdir HOMEBREW_REPOSITORY do
     system git, "config", "--local", "--replace-all", "homebrew.analyticsmessage", "true"
   end
 else
   puts "Run `brew update --force` to complete installation by installing:"
-  if git
-    puts "#{HOMEBREW_PREFIX}/share/doc/homebrew"
-    puts "#{HOMEBREW_PREFIX}/share/man/man1/brew.1"
-    puts "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_brew"
-    puts "#{HOMEBREW_PREFIX}/etc/bash_completion.d/brew"
-    puts "#{HOMEBREW_REPOSITORY}/.git"
-  end
+  puts "#{HOMEBREW_PREFIX}/share/doc/homebrew"
+  puts "#{HOMEBREW_PREFIX}/share/man/man1/brew.1"
+  puts "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_brew"
+  puts "#{HOMEBREW_PREFIX}/etc/bash_completion.d/brew"
+  puts "#{HOMEBREW_REPOSITORY}/.git"
 end

--- a/uninstall
+++ b/uninstall
@@ -93,7 +93,11 @@ if $HOMEBREW_PREFIX_CANDIDATES.empty? # Attempt to locate Homebrew unless `--pat
 end
 
 HOMEBREW_PREFIX = $HOMEBREW_PREFIX_CANDIDATES.detect do |p|
-  p.directory? && (p/".git").exist? || (p/"bin/brew").executable?
+  next unless p.directory?
+  if p.to_s == "/usr/local" && File.exist?("/usr/local/Homebrew/.git")
+    next true
+  end
+  (p/".git").exist? || (p/"bin/brew").executable?
 end
 abort "Failed to locate Homebrew!" if HOMEBREW_PREFIX.nil?
 
@@ -121,7 +125,21 @@ $HOMEBREW_FILES = gitignore.split("\n").select { |line| line.start_with? "!" }.
   map { |line| line.chomp("/").gsub(%r{^!?/}, "") }.
   reject { |line| %w[bin share share/doc].include?(line) }.
   map { |p| HOMEBREW_REPOSITORY/p }
-$HOMEBREW_FILES << HOMEBREW_REPOSITORY/".git"
+if HOMEBREW_PREFIX.to_s != HOMEBREW_REPOSITORY.to_s
+  $HOMEBREW_FILES << HOMEBREW_REPOSITORY
+  $HOMEBREW_FILES += %w[
+    bin/brew
+    etc/bash_completion.d/brew
+    share/doc/homebrew
+    share/man/man1/brew.1
+    share/man/man1/brew-cask.1
+    share/zsh/site-functions/_brew
+    share/zsh/site-functions/_brew_cask
+    var/homebrew/locks/update
+  ].map { |p| HOMEBREW_PREFIX/p }
+else
+  $HOMEBREW_FILES << HOMEBREW_REPOSITORY/".git"
+end
 $HOMEBREW_FILES << HOMEBREW_CELLAR
 
 unless options[:skip_cache_and_logs]
@@ -196,8 +214,16 @@ $HOMEBREW_FILES.each do |file|
   end
 end
 
+# Invalidate sudo timestamp before exiting
+at_exit { Kernel.system "/usr/bin/sudo", "-k" }
+
+def sudo *args
+  ohai "/usr/bin/sudo", *args
+  system "/usr/bin/sudo", *args
+end
+
 ohai "Removing empty directories..." unless options[:quiet]
-paths = %W[Frameworks bin etc include lib opt sbin share var].
+paths = %W[Cellar Homebrew Frameworks bin etc include lib opt sbin share var].
   map { |p| HOMEBREW_PREFIX/p }.select(&:exist?).map(&:to_s)
 if paths.any?
   args = paths + %W[-name .DS_Store]
@@ -207,7 +233,7 @@ if paths.any?
     args << "-delete"
   end
   puts "Would delete:" if options[:dry_run]
-  system "/usr/bin/find", *args
+  sudo "/usr/bin/find", *args
   args = paths + %W[-depth -type d -empty]
   if options[:dry_run]
     args << "-print"
@@ -215,15 +241,18 @@ if paths.any?
     args += %W[-exec rmdir {} ;]
   end
   puts "Would remove directories:" if options[:dry_run]
-  system "/usr/bin/find", *args
+  sudo "/usr/bin/find", *args
 end
 
 if options[:dry_run]
   exit
 else
-  # remove HOMEBREW_REPOSITORY HOMEBREW_PREFIX if they're empty.
-  Kernel.system "rmdir #{HOMEBREW_REPOSITORY} &>/dev/null"
-  Kernel.system "rmdir #{HOMEBREW_PREFIX} &>/dev/null"
+  if HOMEBREW_PREFIX.to_s != "/usr/local" && HOMEBREW_PREFIX.exist?
+    sudo "rmdir", "#{HOMEBREW_PREFIX}"
+  end
+  if HOMEBREW_PREFIX.to_s != HOMEBREW_REPOSITORY.to_s && HOMEBREW_REPOSITORY.exist?
+    sudo "rmdir", "#{HOMEBREW_REPOSITORY}"
+  end
 end
 
 unless options[:quiet]
@@ -243,17 +272,7 @@ residual_files.uniq!
 unless residual_files.empty? || options[:quiet]
   puts "The following possible Homebrew files were not deleted:"
   residual_files.each(&:pretty_print)
-  puts "You may consider to remove them by yourself.\n"
-end
-
-if /darwin/i === RUBY_PLATFORM && HOMEBREW_PREFIX.exist? &&
-  HOMEBREW_PREFIX.to_s == "/usr/local" && !options[:quiet]
-  puts <<-EOS
-You may want to restore /usr/local's original permissions
-  sudo chmod 0755 /usr/local
-  sudo chown root:wheel /usr/local
-
-EOS
+  puts "You may wish to remove them yourself.\n"
 end
 
 exit 1 if $failed


### PR DESCRIPTION
A bunch of users end up in a state where they can neither install nor uninstall if their internet connection dies half way through installation. Instead let's allow the installer to be rerun and have the
uninstaller do a more thorough cleanup of our new locations and use `sudo` to do so.