### PR TITLE
install: tweak git fetch options.

### DIFF
--- a/install
+++ b/install
@@ -261,7 +261,8 @@ Dir.chdir HOMEBREW_REPOSITORY do
     # ensure we don't munge line endings on checkout
     system git, "config", "core.autocrlf", "false"
 
-    args = git, "fetch", "origin", "master:refs/remotes/origin/master", "-n"
+    args = git, "fetch", "origin", "master:refs/remotes/origin/master",
+                "--prune", "--tags", "--force"
     args << "--depth=1" unless ARGV.include?("--full") || !ENV["HOMEBREW_DEVELOPER"].nil?
     system(*args)
 


### PR DESCRIPTION
`--force` particularly will avoid some issues we've seen with people trying to run `install` on pre-migration Git repositories e.g. http://discourse.brew.sh/t/partial-install-cannot-continue/200