### PR TITLE
not fetching unnecessary tags

### DIFF
--- a/install
+++ b/install
@@ -290,8 +290,7 @@ Dir.chdir HOMEBREW_REPOSITORY do
     # ensure we don't munge line endings on checkout
     system git, "config", "core.autocrlf", "false"
 
-    args = git, "fetch", "origin", "master:refs/remotes/origin/master",
-           "--tags", "--force"
+    args = git, "fetch", "origin", "master:refs/remotes/origin/master", "--force"
     args << "--depth=1" unless ARGV.include?("--full") || !ENV["HOMEBREW_DEVELOPER"].nil?
     system(*args)
 


### PR DESCRIPTION
As far as I can see tags are never used by the install script