### PR TITLE
Fix Ruby 1.8 support.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
-AllCops:
-  TargetRubyVersion: 2.0
+# Ruby 1.8 compatibility (for OS X < 10.10)
+Style/DotPosition:
+  EnforcedStyle: trailing
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
 
 Metrics/AbcSize:
   Enabled: false
@@ -73,10 +78,6 @@ Style/EmptyLineBetweenDefs:
 Style/FileName:
   Regex: !ruby/regexp /^[\w\@\-\+\.]+(\.rb)?$/
 
-# depends_on a: :b looks weird in formulae.
-Style/HashSyntax:
-  EnforcedStyle: hash_rockets
-
 # disabled until it respects line length
 Style/IfUnlessModifier:
   Enabled: false
@@ -134,10 +135,6 @@ Style/StringLiteralsInInterpolation:
 
 Style/TernaryParentheses:
   Enabled: false
-
-# makes diffs nicer
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: comma
 
 Style/VariableNumber:
   Enabled: false

--- a/install
+++ b/install
@@ -197,19 +197,19 @@ group_chmods = %w[ bin etc Frameworks include lib sbin share var
                    etc/bash_completion.d lib/pkgconfig var/log
                    share/aclocal share/doc share/info share/locale share/man
                    share/man/man1 share/man/man2 share/man/man3 share/man/man4
-                   share/man/man5 share/man/man6 share/man/man7 share/man/man8]
-               .map { |d| File.join(HOMEBREW_PREFIX, d) }
-               .select { |d| chmod?(d) }
+                   share/man/man5 share/man/man6 share/man/man7 share/man/man8].
+               map { |d| File.join(HOMEBREW_PREFIX, d) }.
+               select { |d| chmod?(d) }
 # zsh refuses to read from these directories if group writable
-zsh_dirs = %w[share/zsh share/zsh/site-functions]
-           .map { |d| File.join(HOMEBREW_PREFIX, d) }
+zsh_dirs = %w[share/zsh share/zsh/site-functions].
+           map { |d| File.join(HOMEBREW_PREFIX, d) }
 user_chmods = zsh_dirs.select { |d| user_only_chmod?(d) }
 chmods = group_chmods + user_chmods
 chowns = chmods.select { |d| chown?(d) }
 chgrps = chmods.select { |d| chgrp?(d) }
-mkdirs = %w[Cellar Homebrew Frameworks bin etc include lib opt sbin share share/zsh share/zsh/site-functions var]
-         .map { |d| File.join(HOMEBREW_PREFIX, d) }
-         .reject { |d| File.directory?(d) }
+mkdirs = %w[Cellar Homebrew Frameworks bin etc include lib opt sbin share share/zsh share/zsh/site-functions var].
+         map { |d| File.join(HOMEBREW_PREFIX, d) }.
+         reject { |d| File.directory?(d) }
 
 unless group_chmods.empty?
   ohai "The following existing directories will be made group writable:"

--- a/uninstall
+++ b/uninstall
@@ -9,7 +9,7 @@ options = {
   :force => false,
   :quiet => false,
   :dry_run => false,
-  :skip_cache_and_logs => false,
+  :skip_cache_and_logs => false
 }
 
 # global status to indicate whether there is anything wrong.
@@ -157,11 +157,11 @@ rescue Errno::ENOENT
 end
 abort "Failed to fetch Homebrew .gitignore!" if gitignore.empty?
 
-homebrew_files = gitignore.split("\n")
-                          .select { |line| line.start_with? "!" }
-                          .map { |line| line.chomp("/").gsub(%r{^!?/}, "") }
-                          .reject { |line| %w[bin share share/doc].include?(line) }
-                          .map { |p| HOMEBREW_REPOSITORY/p }
+homebrew_files = gitignore.split("\n").
+                 select { |line| line.start_with? "!" }.
+                 map { |line| line.chomp("/").gsub(%r{^!?/}, "") }.
+                 reject { |line| %w[bin share share/doc].include?(line) }.
+                 map { |p| HOMEBREW_REPOSITORY/p }
 if HOMEBREW_PREFIX.to_s != HOMEBREW_REPOSITORY.to_s
   homebrew_files << HOMEBREW_REPOSITORY
   homebrew_files += %w[
@@ -214,10 +214,10 @@ if STDIN.tty? && (!options[:force] && !options[:dry_run])
 end
 
 ohai "Removing Homebrew installation..." unless options[:quiet]
-paths = %w[Frameworks bin etc include lib opt sbin share var]
-        .map { |p| HOMEBREW_PREFIX/p }
-        .select(&:exist?)
-        .map(&:to_s)
+paths = %w[Frameworks bin etc include lib opt sbin share var].
+        map { |p| HOMEBREW_PREFIX/p }.
+        select(&:exist?).
+        map(&:to_s)
 if paths.any?
   args = %w[-E] + paths + %w[-regex .*/info/([^.][^/]*\.info|dir)]
   if options[:dry_run]
@@ -262,10 +262,10 @@ def sudo(*args)
 end
 
 ohai "Removing empty directories..." unless options[:quiet]
-paths = %w[Cellar Homebrew Frameworks bin etc include lib opt sbin share var]
-        .map { |p| HOMEBREW_PREFIX/p }
-        .select(&:exist?)
-        .map(&:to_s)
+paths = %w[Cellar Homebrew Frameworks bin etc include lib opt sbin share var].
+        map { |p| HOMEBREW_PREFIX/p }.
+        select(&:exist?).
+        map(&:to_s)
 if paths.any?
   args = paths + %w[-name .DS_Store]
   if options[:dry_run]


### PR DESCRIPTION
This is still needed on older OS X versions at installation time.