### PR TITLE
Only invalidate `sudo` if it wasn’t active before `install`.

### DIFF
--- a/install
+++ b/install
@@ -158,8 +158,14 @@ def chgrp?(d)
   !File.grpowned?(d)
 end
 
-# Invalidate sudo timestamp before exiting
-at_exit { Kernel.system "/usr/bin/sudo", "-k" }
+# Invalidate sudo timestamp before exiting (if it wasn't active before).
+begin
+  $stderr.reopen("/dev/null")
+  Kernel.system "/usr/bin/sudo", "-n", "-v"
+  at_exit { Kernel.system "/usr/bin/sudo", "-k" } unless $?.success?
+ensure
+  $stderr.reopen(STDERR)
+end
 
 # The block form of Dir.chdir fails later if Dir.CWD doesn't exist which I
 # guess is fair enough. Also sudo prints a warning message for no good reason


### PR DESCRIPTION
The `sudo` timestamp should only be invalidated if `sudo` was activated first inside the `install` script. If the timestamp was active before the script, it should also be left intact after the script.
