### PR TITLE
Add support for `SUDO_ASKPASS`.

### DIFF
--- a/install
+++ b/install
@@ -64,6 +64,7 @@ def system(*args)
 end
 
 def sudo(*args)
+  args.unshift("-A") unless ENV["SUDO_ASKPASS"].nil?
   ohai "/usr/bin/sudo", *args
   system "/usr/bin/sudo", *args
 end


### PR DESCRIPTION
Allows running 

```
SUDO_ASKPASS="/path/to/askpass.sh" /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
```