### PR TITLE
Revert "Only invalidate `sudo` if it wasn’t active before `install`."

### DIFF
--- a/install
+++ b/install
@@ -158,14 +158,8 @@ def chgrp?(d)
   !File.grpowned?(d)
 end
 
-# Invalidate sudo timestamp before exiting (if it wasn't active before).
-begin
-  $stderr.reopen("/dev/null")
-  Kernel.system "/usr/bin/sudo", "-n", "-v"
-  at_exit { Kernel.system "/usr/bin/sudo", "-k" } unless $?.success?
-ensure
-  $stderr.reopen(STDERR)
-end
+# Invalidate sudo timestamp before exiting
+at_exit { Kernel.system "/usr/bin/sudo", "-k" }
 
 # The block form of Dir.chdir fails later if Dir.CWD doesn't exist which I
 # guess is fair enough. Also sudo prints a warning message for no good reason


### PR DESCRIPTION
Reverts Homebrew/install#84

https://github.com/reitermarkus/install/blob/c2c00a4634b425588ee150dbb7978dd12c034c5e/install#L163 means that `stderr` output is never displayed. CC @reitermarkus 

Closes https://github.com/Homebrew/install/issues/87