### PR TITLE
Allow running installer on 10.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ Layout/DotPosition:
   EnforcedStyle: trailing
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
+Style/SymbolProc:
+  Enabled: false
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: no_comma
 
@@ -75,7 +77,7 @@ Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
 # dashes in filenames are typical
-Style/FileName:
+Naming/FileName:
   Regex: !ruby/regexp /^[\w\@\-\+\.]+(\.rb)?$/
 
 # disabled until it respects line length
@@ -136,7 +138,7 @@ Style/StringLiteralsInInterpolation:
 Style/TernaryParentheses:
   Enabled: false
 
-Style/VariableNumber:
+Naming/VariableNumber:
   Enabled: false
 
 Style/WordArray:
@@ -144,4 +146,10 @@ Style/WordArray:
 
 # don't have a helper in install/uninstall
 Layout/IndentHeredoc:
+  Enabled: false
+
+Lint/RescueWithoutErrorClass:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 os: osx
-env: OSX=10.11
-osx_image: xcode7.3
+osx_image: xcode8.3
 rvm: system
 
 # Remove Xcode and CommandLineTools included in default macOS image.

--- a/install
+++ b/install
@@ -91,7 +91,7 @@ class Version
   attr_reader :parts
 
   def initialize(str)
-    @parts = str.split(".").map(&:to_i)
+    @parts = str.split(".").map { |p| p.to_i }
   end
 
   def <=>(other)
@@ -167,7 +167,7 @@ Dir.chdir "/usr"
 
 ####################################################################### script
 abort "See Linuxbrew: http://linuxbrew.sh/" if RUBY_PLATFORM.to_s.downcase.include?("linux")
-abort "MacOS too old, see: https://github.com/mistydemeo/tigerbrew" if macos_version < "10.6"
+abort "Mac OS X too old, see: https://github.com/mistydemeo/tigerbrew" if macos_version < "10.5"
 abort "Don't run this as root!" if Process.uid.zero?
 abort <<-EOABORT unless `dsmemberutil checkmembership -U "#{ENV["USER"]}" -G admin`.include? "user is a member"
 This script requires the user #{ENV["USER"]} to be an Administrator.
@@ -311,6 +311,7 @@ Dir.chdir HOMEBREW_REPOSITORY do
     # -m to stop tar erroring out if it can't modify the mtime for root owned directories
     # pipefail to cause the exit status from curl to propagate if it fails
     curl_flags = "fsSL"
+    curl_flags += "k" if macos_version < "10.6"
     core_tap = "#{HOMEBREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core"
     system "/bin/bash -o pipefail -c '/usr/bin/curl -#{curl_flags} #{BREW_REPO}/tarball/master | /usr/bin/tar xz -m --strip 1'"
 


### PR DESCRIPTION
It requires `--insecure` but if we can make it work: we may as well.