### PR TITLE
install: always perform full clone.

### DIFF
--- a/install
+++ b/install
@@ -299,7 +299,6 @@ Dir.chdir HOMEBREW_REPOSITORY do
 
     args = git, "fetch", "origin", "master:refs/remotes/origin/master",
            "--tags", "--force"
-    args << "--depth=1" unless ARGV.include?("--full") || !ENV["HOMEBREW_DEVELOPER"].nil?
     system(*args)
 
     system git, "reset", "--hard", "origin/master"


### PR DESCRIPTION
This means we can always use `git describe` to get the version accurately.

Fixes https://github.com/Homebrew/brew/issues/3187