### PR TITLE
Add notice if Xcode CLT is to be installed

### DIFF
--- a/install
+++ b/install
@@ -227,6 +227,9 @@ unless mkdirs.empty?
   ohai "The following new directories will be created:"
   puts(*mkdirs)
 end
+if should_install_command_line_tools?
+  ohai "The Xcode Command Line Tools will be installed."
+end
 
 wait_for_user if STDIN.tty? && !ENV["TRAVIS"]
 


### PR DESCRIPTION
I am happy to see the Xcode Command Line Tools (CLT) automatically installed but would like to see the notice before confirming installation. I think this notice is needed to be in line with the following statements from <https://docs.brew.sh/Installation.html> (<https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation>):
<blockquote>
 It tells you exactly what it will do before it does it too. And you have to confirm everything it will do before it starts.
</blockquote>

I tested that this change with and without `/Library/Developer/CommandLineTools` present in my file system, using the following command:

```sh
/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/brodybits/install/xcode-clt-notice/install)"
```