### PR TITLE
install: always install Xcode CLT.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,7 +148,7 @@ Style/WordArray:
 Layout/IndentHeredoc:
   Enabled: false
 
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Enabled: false
 
 Naming/HeredocDelimiterNaming:

--- a/install
+++ b/install
@@ -110,8 +110,8 @@ end
 def should_install_command_line_tools?
   return false if force_curl?
   return false if macos_version < "10.9"
-  developer_dir = `/usr/bin/xcode-select -print-path 2>/dev/null`.chomp
-  developer_dir.empty? || !File.exist?("#{developer_dir}/usr/bin/git")
+  !File.exist?("/Library/Developer/CommandLineTools/usr/bin/git") ||
+    !File.exist?("/usr/include/iconv.h")
 end
 
 def git


### PR DESCRIPTION
If they aren't already installed. This means we don't tell users to immediately install it afterwards.