### PR TITLE
fix command line tools checking on 10.14

### DIFF
--- a/install
+++ b/install
@@ -110,7 +110,12 @@ end
 def should_install_command_line_tools?
   return false if force_curl?
   return false if macos_version < "10.9"
-  !File.exist?("/Library/Developer/CommandLineTools/usr/bin/git")
+  if macos_version > "10.13"
+    !File.exist?("/Library/Developer/CommandLineTools/usr/bin/git")
+  else
+    !File.exist?("/Library/Developer/CommandLineTools/usr/bin/git") ||
+      !File.exist?("/usr/include/iconv.h")
+  end
 end
 
 def git

--- a/install
+++ b/install
@@ -110,8 +110,7 @@ end
 def should_install_command_line_tools?
   return false if force_curl?
   return false if macos_version < "10.9"
-  !File.exist?("/Library/Developer/CommandLineTools/usr/bin/git") ||
-    !File.exist?("/usr/include/iconv.h")
+  !File.exist?("/Library/Developer/CommandLineTools/usr/bin/git")
 end
 
 def git


### PR DESCRIPTION
Install command line tools for Xcode 10 won't create `/usr/include/` folder neither `iconv.h` file, that will make install script stuck on downloading-installing procedure on 

```
==> Installing the Command Line Tools (expect a GUI popup):
==> /usr/bin/sudo /usr/bin/xcode-select --install
xcode-select: error: command line tools are already installed, use "Software Update" to install updates
Failed during: /usr/bin/sudo /usr/bin/xcode-select --install
```
