### PR TITLE
Ask command line tools to install header files to /usr/include

### DIFF
--- a/install
+++ b/install
@@ -272,7 +272,7 @@ if should_install_command_line_tools?
   
   if macos_version > "10.13"
     # Tell CLT to install header files to /usr/include
-    sudo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /"
+    sudo "installer", "-pkg", "/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg", "-target", "/"
   end
 end
 

--- a/install
+++ b/install
@@ -269,6 +269,11 @@ if should_install_command_line_tools?
   sudo "/usr/sbin/softwareupdate", "-i", clt_label
   sudo "/bin/rm", "-f", clt_placeholder
   sudo "/usr/bin/xcode-select", "--switch", "/Library/Developer/CommandLineTools"
+  
+  if macos_version > "10.13"
+    # Tell CLT to install header files to /usr/include
+    sudo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /"
+  end
 end
 
 # Headless install may have failed, so fallback to original 'xcode-select' method


### PR DESCRIPTION
On 10.14, CLT installation won't install header files to /usr/include automatically,
which will affect many package like Node.js and most pips rely on zlib, and prevent brew to detect CLT properly. trigger this installation package will fix it.