### PR TITLE
install: update non-default prefix instructions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,7 @@ script:
   - ./install
   - brew install ack
   - ./uninstall -f
+
+branches:
+  only:
+    - master

--- a/install
+++ b/install
@@ -1,7 +1,7 @@
 #!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
-# This script installs to /usr/local only. To install elsewhere you can just
-# untar https://github.com/Homebrew/brew/tarball/master anywhere you like or
-# change the value of HOMEBREW_PREFIX.
+# This script installs to /usr/local only. To install elsewhere (which is
+# unsupported) you can untar https://github.com/Homebrew/brew/tarball/master
+# anywhere you like.
 HOMEBREW_PREFIX = "/usr/local".freeze
 HOMEBREW_REPOSITORY = "/usr/local/Homebrew".freeze
 HOMEBREW_CACHE = "#{ENV["HOME"]}/Library/Caches/Homebrew".freeze


### PR DESCRIPTION
Note this isn't supported and the install script isn't designed to be edited.

Fixes #133 