### PR TITLE
can force no install xcode CLI with NO_CLI=true in env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 More installation information and options at http://docs.brew.sh/Installation.html.
 
+*Having trouble with the xcode command line tools?* Try this:
+
+```bash
+NO_CLI=true /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+
 ## Uninstall Homebrew
 ```bash
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"

--- a/install
+++ b/install
@@ -18,6 +18,8 @@ MACOS_OLDEST_SUPPORTED = "10.11".freeze
 ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
 ENV["HOMEBREW_NO_ANALYTICS_MESSAGE_OUTPUT"] = "1"
 
+FORCE_NO_INSTALL_COMMAND_LINE_TOOLS = ENV["NO_CLI"] === "true"
+
 module Tty
   module_function
 
@@ -113,6 +115,7 @@ def macos_version
 end
 
 def should_install_command_line_tools?
+  return false if FORCE_NO_INSTALL_COMMAND_LINE_TOOLS
   return false if force_curl?
   return false if macos_version < "10.9"
   if macos_version > "10.13"


### PR DESCRIPTION
I was having trouble with the install script - it kept failing trying to install the Xcode CLI ( which is already on my machine - but in a different location )

This PR will allow this: 

NO_CLI=true /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

which will force the should_install_command_line_tools func to return false