### PR TITLE
Don't wait for user input on CI

### DIFF
--- a/install
+++ b/install
@@ -274,7 +274,7 @@ if should_install_command_line_tools?
   ohai "The Xcode Command Line Tools will be installed."
 end
 
-wait_for_user if STDIN.tty? && !ENV["TRAVIS"] && !ENV["CI"]
+wait_for_user if STDIN.tty? && !ENV["CI"]
 
 if File.directory? HOMEBREW_PREFIX
   sudo "/bin/chmod", "u+rwx", *chmods unless chmods.empty?


### PR DESCRIPTION
This allows us to install brew on CircleCI where `CI` is set to true:
https://circleci.com/docs/2.0/env-vars/