### PR TITLE
Fix  Bug: missing HOMEBREW_CORE_TAP

### DIFF
--- a/install
+++ b/install
@@ -379,10 +379,12 @@ Dir.chdir HOMEBREW_REPOSITORY do
 
   system git, "reset", "--hard", "origin/master"
 
-  unless can_macos_use_tls12?
+  if can_macos_use_tls12?
     system git, "clone", "--depth", "1", CORE_TAP_REPO_INSECURE, HOMEBREW_CORE_TAP
     system git, "config", "--file", "#{HOMEBREW_CORE_TAP}/.git/config", "core.autocrlf", "false"
     ENV["HOMEBREW_BOTTLE_DOMAIN"] = "http://homebrew.bintray.com"
+  else
+    abort "Require Mac OSX version>=10.9"
   end
 
   system "ln", "-sf", "#{HOMEBREW_REPOSITORY}/bin/brew", "#{HOMEBREW_PREFIX}/bin/brew"

--- a/install
+++ b/install
@@ -380,12 +380,13 @@ Dir.chdir HOMEBREW_REPOSITORY do
   system git, "reset", "--hard", "origin/master"
 
   if can_macos_use_tls12?
-    system git, "clone", "--depth", "1", CORE_TAP_REPO_INSECURE, HOMEBREW_CORE_TAP
-    system git, "config", "--file", "#{HOMEBREW_CORE_TAP}/.git/config", "core.autocrlf", "false"
-    ENV["HOMEBREW_BOTTLE_DOMAIN"] = "http://homebrew.bintray.com"
+    system git, "clone", "--depth", "1", CORE_TAP_REPO, HOMEBREW_CORE_TAP
   else
-    abort "Require Mac OSX version>=10.9"
+    system git, "clone", "--depth", "1", CORE_TAP_REPO_INSECURE, HOMEBREW_CORE_TAP
   end
+  system git, "config", "--file", "#{HOMEBREW_CORE_TAP}/.git/config", "core.autocrlf", "false"
+  ENV["HOMEBREW_BOTTLE_DOMAIN"] = "http://homebrew.bintray.com"
+
 
   system "ln", "-sf", "#{HOMEBREW_REPOSITORY}/bin/brew", "#{HOMEBREW_PREFIX}/bin/brew"
 


### PR DESCRIPTION
Fix the bug that missing HOMEBREW_CORE_TAP with newly installation.

https://github.com/Homebrew/brew/issues/5570#event-2085902879