### PR TITLE
install: use /usr/bin/ruby.

### DIFF
--- a/install
+++ b/install
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
+#!/usr/bin/ruby
 # This script installs to /usr/local only. To install elsewhere (which is
 # unsupported) you can untar https://github.com/Homebrew/brew/tarball/master
 # anywhere you like.


### PR DESCRIPTION
This should make the Linux failure case a little nicer and SIP protects us from El Capitan onwards.