### PR TITLE
Update install: use shallow cloning

### DIFF
--- a/install
+++ b/install
@@ -351,7 +351,7 @@ Dir.chdir HOMEBREW_REPOSITORY do
   system "git", "config", "core.autocrlf", "false"
 
   system "git", "fetch", "origin", "master:refs/remotes/origin/master",
-         "--tags", "--force"
+         "--tags", "--force", "--depth", "1"
 
   system "git", "reset", "--hard", "origin/master"
 


### PR DESCRIPTION
it is faster than cloning the repository's whole Git history