### PR TITLE
Use github.com URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install Homebrew
 
 ```bash
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/usr/bin/ruby -e "$(curl -fsSL https://github.com/Homebrew/install/raw/master/install)"
 ```
 
 More installation information and options at https://docs.brew.sh/Installation.html.
@@ -15,7 +15,7 @@ Install Homebrew on Linux and Windows 10 Subsystem for Linux: https://docs.brew.
 ## Uninstall Homebrew
 
 ```bash
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+/usr/bin/ruby -e "$(curl -fsSL https://github.com/Homebrew/install/raw/master/uninstall)"
 ```
 
 Download the uninstall script and run `./uninstall --help` to view more uninstall options.


### PR DESCRIPTION
This is just a proposal to use **github.com** URLs instead of **githubusercontent.com**.

1. It's shorter, makes the full line easier to read.
2. It looks more legit, less like some sort of phishing attack.
3. It's what the GitHub UI uses, so it's probably a slightly more stable interface.

I haven't changed them everywhere yet, just wanted to spark a conversation. If you like it, I will do it everywhere to keep things consistent.