### PR TITLE
Remove `--local` from `git config` commands as it's the default

### DIFF
--- a/install
+++ b/install
@@ -371,8 +371,8 @@ puts <<-EOS
 EOS
 
 Dir.chdir HOMEBREW_REPOSITORY do
-  system "git", "config", "--local", "--replace-all", "homebrew.analyticsmessage", "true"
-  system "git", "config", "--local", "--replace-all", "homebrew.caskanalyticsmessage", "true"
+  system "git", "config", "--replace-all", "homebrew.analyticsmessage", "true"
+  system "git", "config", "--replace-all", "homebrew.caskanalyticsmessage", "true"
 end
 
 ohai "Next steps:"


### PR DESCRIPTION
- The `--local` option doesn't exist in early versions of git (~1.7),
  but its behaviour is the default (saving in the current repo's .git
  directory).
- As it's the default across versions, we don't need to specify it
  everywhere. The `global` and `system` flags are still legitimate.
- Reported in https://github.com/Linuxbrew/install/issues/78, and we'll
  merge these changes into that fork.