### PR TITLE
Separately fetch commits and tags

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -482,6 +482,7 @@ ohai "Downloading and installing Homebrew..."
   # ensure we don't munge line endings on checkout
   execute "git" "config" "core.autocrlf" "false"
 
+  execute "git" "fetch" "origin" "--force"
   execute "git" "fetch" "origin" "--tags" "--force"
 
   execute "git" "reset" "--hard" "origin/master"


### PR DESCRIPTION
This is necessary for older gits, which will only fetch the tags and not
e.g., the `master` ref.

Tested on git 1.8.3