### PR TITLE
Add set -e to exit upon errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -u
+set -e
 
 # First check if the OS is Linux.
 if [[ "$(uname)" = "Linux" ]]; then


### PR DESCRIPTION
Testing on Linux, running install.sh on a system that does not yet have Git installed results in apparent success.

Adding ``set -e`` ensures that the install script exits when errors are thrown.