### PR TITLE
Don't create $HOMEBREW_CACHE with sudo on Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -412,7 +412,11 @@ if [[ "${#mkdirs[@]}" -gt 0 ]]; then
 fi
 
 if ! [[ -d "${HOMEBREW_CACHE}" ]]; then
-  execute_sudo "/bin/mkdir" "-p" "${HOMEBREW_CACHE}"
+  if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
+    execute_sudo "/bin/mkdir" "-p" "${HOMEBREW_CACHE}"
+  else
+    "/bin/mkdir" "-p" "${HOMEBREW_CACHE}"
+  fi
 fi
 if exists_but_not_writable "${HOMEBREW_CACHE}"; then
   execute_sudo "/bin/chmod" "g+rwx" "${HOMEBREW_CACHE}"

--- a/install.sh
+++ b/install.sh
@@ -429,7 +429,7 @@ if ! [[ -d "${HOMEBREW_CACHE}" ]]; then
   if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
     execute_sudo "/bin/mkdir" "-p" "${HOMEBREW_CACHE}"
   else
-    "/bin/mkdir" "-p" "${HOMEBREW_CACHE}"
+    execute "/bin/mkdir" "-p" "${HOMEBREW_CACHE}"
   fi
 fi
 if exists_but_not_writable "${HOMEBREW_CACHE}"; then


### PR DESCRIPTION
Don't execute `sudo` when creating `$HOMEBREW_CACHE`, so that if `~/.cache` (the parent directory of `$HOMEBREW_CACHE` on Linux) doesn't exist, the installer doesn't leave behind a root-owned `~/.cache`.

Closes #279.

Tested with the following Dockerfile:
```docker
FROM ubuntu:19.10

# Install brew deps and sudo
RUN apt-get update \
    && apt-get install -y \
    sudo \
    libc6 \
    gcc \
    make \
    curl \
    file \
    git

# Add a new user and add them to sudoers
# Setup sudo to be used without a password
RUN useradd --create-home user1 \
    && usermod -aG sudo user1 \
    && echo "user1 ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

USER user1
WORKDIR /home/user1

# Commenting this out USED TO cause a /home/user1/.cache directory to be created which is owned by root:root
# RUN mkdir /home/user1/.cache

COPY install.sh /home/user1/install.sh
RUN /bin/bash -c "/home/user1/install.sh"

RUN ls -l -a /home/user1
```