### PR TITLE
Fix terminal device

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,8 @@ execute_sudo() {
 }
 
 getc() {
-  local save_state=$(/bin/stty -g)
+  local save_state
+  save_state=$(/bin/stty -g)
   /bin/stty raw -echo
   IFS= read -r -n 1 -d '' "$@"
   /bin/stty "$save_state"

--- a/install.sh
+++ b/install.sh
@@ -115,9 +115,10 @@ execute_sudo() {
 }
 
 getc() {
+  local save_state=$(/bin/stty -g)
   /bin/stty raw -echo
   IFS= read -r -n 1 -d '' "$@"
-  /bin/stty -raw -echo
+  /bin/stty "$save_state"
 }
 
 wait_for_user() {


### PR DESCRIPTION
Fix bug introduced in b2dd833c.
I also suggest using `stty -g` to save terminal state and then restore to it.

CC @sjackman