### PR TITLE
workflows/tests: remove unneeded `pkgutil --forget`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,6 @@ jobs:
       run: |
         sudo rm -rf /Applications/Xcode.app \
                     /Library/Developer/CommandLineTools
-        sudo pkgutil --forget com.apple.pkg.CLTools_Executables
         sudo xcode-select --reset
 
     - name: Set up Homebrew PATH


### PR DESCRIPTION
This was only needed on older versions of macOS.