### PR TITLE
Pass down cmd arguments to bash, fixes #299

### DIFF
--- a/uninstall
+++ b/uninstall
@@ -7,4 +7,4 @@ Bash. Please migrate to the following command:
 
 EOS
 
-Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"'
+Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"' + ' uninstall ' +  ARGV.join(" ")


### PR DESCRIPTION
This should pass down the ruby command line parameters to bash. The `man bash` docs say:

```
  -c string If the -c option is present, then commands are read from string. If
     there are arguments after the string, they are assigned to the positional 
     parameters, starting with $0.
```

So therefore we first add parameter `$0` (which is normally then filename of the script you are invoking) and call it `uninstall` (it can ban be anything). And after that we append the command line arguments in the same order as we got them.

You can test it like so:

```sh
ruby uninstall --help
```

Or so:

```sh
ruby uninstall --dry-run --force
```