### PR TITLE
Adds support for SUDO_ASKPASS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,8 +57,13 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
+  local -a args
+  if [[ -z=n "${SUDO_ASKPASS-}" ]]; then
+    args=("-A")
+  fi
+
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
-    /usr/bin/sudo -l mkdir &>/dev/null
+    /usr/bin/sudo "${args[@]-}" -l mkdir &>/dev/null
     HAVE_SUDO_ACCESS="$?"
   fi
 


### PR DESCRIPTION
If SUDO_ASKPASS is defined, then it will be used instead of requiring entering the SUDO password via the terminal.

The current workaround to support SUDO_ASKPASS during the installation of Homebrew is to also provide HAVE_SUDO_ACCESS before executing the installer.