### PR TITLE
Added support for SUDO_ASKPASS to Homebrew/install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
   local -a args
-  if [[ -z=n "${SUDO_ASKPASS-}" ]]; then
+  if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")
   fi
 


### PR DESCRIPTION
Otherwise, HAVE_SUDO_ACCESS has to be defined outside of the installer to support SUDO_ASKPASS, which I don't think is intended.