### PR TITLE
exit at subshell failed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -565,7 +565,7 @@ ohai "Downloading and installing Homebrew..."
   execute "ln" "-sf" "${HOMEBREW_REPOSITORY}/bin/brew" "${HOMEBREW_PREFIX}/bin/brew"
 
   execute "${HOMEBREW_PREFIX}/bin/brew" "update" "--force"
-)
+) || exit 1
 
 if [[ ":${PATH}:" != *":${HOMEBREW_PREFIX}/bin:"* ]]; then
   warn "${HOMEBREW_PREFIX}/bin is not in your PATH."
@@ -600,7 +600,7 @@ EOS
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
   execute "git" "config" "--replace-all" "homebrew.analyticsmessage" "true"
   execute "git" "config" "--replace-all" "homebrew.caskanalyticsmessage" "true"
-)
+) || exit 1
 
 ohai "Next steps:"
 echo "- Run \`brew help\` to get started"


### PR DESCRIPTION
```bash
==> This script will install:
/usr/local/bin/brew
/usr/local/share/doc/homebrew
/usr/local/share/man/man1/brew.1
/usr/local/share/zsh/site-functions/_brew
/usr/local/etc/bash_completion.d/brew
/usr/local/Homebrew

Press RETURN to continue or any other key to abort
==> Downloading and installing Homebrew...
fatal: unable to access 'https://github.com/Homebrew/brew/': Failed to connect to github.com port 443: Operation timed out
Failed during: git fetch origin --force
==> Installation successful!

==> Homebrew has enabled anonymous aggregate formulae and cask analytics.
Read the analytics documentation (and how to opt-out) here:
  https://docs.brew.sh/Analytics
No analytics data has been sent yet (or will be during this `install` run).

==> Homebrew is run entirely by unpaid volunteers. Please consider donating:
  https://github.com/Homebrew/brew#donations

==> Next steps:
- Run `brew help` to get started
- Further documentation:
    https://docs.brew.sh
```

the install.sh will just continue even if failed to clone remote repository