### PR TITLE
Do not install Command Line Tools on ARM Mac

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ fi
 if [[ "$(uname -m)" = "arm64" ]] && [[ "$(uname)" = "Darwin" ]]; then
   HOMEBREW_APPLE_SILICON=1
 fi
+
 # On macOS, this script installs to /usr/local only.
 # On Linux, it installs to /home/linuxbrew/.linuxbrew if you have sudo access
 # and ~/.linuxbrew otherwise.

--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,6 @@ fi
 if [[ "$(uname -m)" = "arm64" ]] && [[ "$(uname)" = "Darwin" ]]; then
   HOMEBREW_APPLE_SILICON=1
 fi
-
-
 # On macOS, this script installs to /usr/local only.
 # On Linux, it installs to /home/linuxbrew/.linuxbrew if you have sudo access
 # and ~/.linuxbrew otherwise.

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 
 # Check if macOS is ARM
 if [[ "$(uname -m)" = "arm64" ]] && [[ "$(uname)" = "Darwin" ]]; then
-  HOMEBREW_MAC_ARM64=1
+  HOMEBREW_APPLE_SILICON=1
 fi
 
 
@@ -183,7 +183,7 @@ should_install_command_line_tools() {
     return 1
   fi
 
-  if [[ -n "${HOMEBREW_MAC_ARM64-}" ]]; then
+  if [[ -n "${HOMEBREW_APPLE_SILICON-}" ]]; then
     return 1;
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,12 @@ if [[ "$(uname)" = "Linux" ]]; then
   HOMEBREW_ON_LINUX=1
 fi
 
+# Check if macOS is ARM
+if [[ "$(uname -m)" = "arm64" ]] && [[ "$(uname)" = "Darwin" ]]; then
+  HOMEBREW_MAC_ARM64=1
+fi
+
+
 # On macOS, this script installs to /usr/local only.
 # On Linux, it installs to /home/linuxbrew/.linuxbrew if you have sudo access
 # and ~/.linuxbrew otherwise.
@@ -175,6 +181,10 @@ should_install_git() {
 should_install_command_line_tools() {
   if [[ -n "${HOMEBREW_ON_LINUX-}" ]]; then
     return 1
+  fi
+
+  if [[ -n "${HOMEBREW_MAC_ARM64-}" ]]; then
+    return 1;
   fi
 
   if version_gt "$macos_version" "10.13"; then


### PR DESCRIPTION
When using Apple Transition Kit installing Command Line Tools is not needed. 

The command line tools are Intel based, and end up breaking things.

*Note*: Brew fails to run because of some Ruby issues. I will try to fix this in another PR.