### PR TITLE
Install: fix Apple Silicon detection under Rosetta

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [[ "$(uname)" = "Linux" ]]; then
 fi
 
 # Check if macOS is ARM
-if [[ "$(uname -m)" = "arm64" ]] && [[ "$(uname)" = "Darwin" ]]; then
+if [[ "$(uname)" = "Darwin" ]] && [[ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo '0')" = "1" ]]; then
   HOMEBREW_APPLE_SILICON=1
 fi
 


### PR DESCRIPTION
`uname` has potentially surprising behaviour under Rosetta: it reports the running Mac as being Intel-based. That's probably correct for many cases, where what we want to check is "is this Mac currently running Intel code". However, in the case where what we want to check for is the actual processor, it will give us the wrong results.

We don't want to install the CLT at all for Apple Silicon Macs, whether the installer is running in Rosetta or not. I've checked, and this `sysctl` check returns `1` if the physical CPU is Apple Silicon, regardless of whether or not it's in Rosetta.

The stderr redirection and `|| '0'` is because this key isn't recognized on older OSs, and therefore trying to access it would cause it to exit 1 without results in the expected format.