### PR TITLE
install.sh: don't try to install CLT on Big Sur.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -188,8 +188,10 @@ should_install_command_line_tools() {
     return 1
   fi
 
-  if [[ -n "${HOMEBREW_APPLE_SILICON-}" ]]; then
-    return 1;
+  # Don't try to install CLT on 11.0/10.16 for now until Apple sorts out their CLT delivery.
+  # TODO: remove this when possible.
+  if [[ -n "${HOMEBREW_APPLE_SILICON-}" ]] || version_ge "$macos_version" "10.16"; then
+    return 1
   fi
 
   if version_gt "$macos_version" "10.13"; then


### PR DESCRIPTION
The current CLT delivery through `softwareupdate` is broken.