### PR TITLE
install.sh: use fewer functions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,18 +166,6 @@ version_lt() {
   [[ "${1%.*}" -lt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -lt "${2#*.}" ]]
 }
 
-should_install_git() {
-  if [[ $(command -v git) ]]; then
-    return 1
-  fi
-}
-
-should_install_curl() {
-  if [[ $(command -v curl) ]]; then
-    return 1
-  fi
-}
-
 should_install_command_line_tools() {
   if [[ -n "${HOMEBREW_ON_LINUX-}" ]]; then
     return 1
@@ -277,7 +265,7 @@ fi
 cd "/usr" || exit 1
 
 ####################################################################### script
-if should_install_git; then
+if ! command -v git >/dev/null; then
     abort "$(cat <<EOABORT
 You must install Git before installing Homebrew. See:
   ${tty_underline}https://docs.brew.sh/Installation${tty_reset}
@@ -285,7 +273,7 @@ EOABORT
 )"
 fi
 
-if should_install_curl; then
+if ! command -v curl >/dev/null; then
     abort "$(cat <<EOABORT
 You must install cURL before installing Homebrew. See:
   ${tty_underline}https://docs.brew.sh/Installation${tty_reset}


### PR DESCRIPTION
@jonchang, unless I'm missing something, I think we can replace `should_install_curl` and `should_install_git` with `! command -v ... >/dev/null` without any loss of functionality.