### PR TITLE
Support use custom BREW_REPO url

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ else
   TOUCH="/bin/touch"
 fi
 BREW_REPO="https://github.com/Homebrew/brew"
+BREW_REPO=${BREW_REPO:-https://github.com/Homebrew/brew}
 
 # TODO: bump version when new macOS is released
 MACOS_LATEST_SUPPORTED="10.15"


### PR DESCRIPTION
Support use custom BREW_REPO url

So I can use mirrors like:

```console
BREW_REPO=https://mirrors.aliyun.com/homebrew/brew.git /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" 
```