### PR TITLE
Use GITHUB_PATH instead of add-path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Set up Homebrew PATH
       run: |
         if [ "$RUNNER_OS" = "macOS" ]; then
-          echo "::add-path::/usr/local/bin:/usr/bin:/bin"
+          echo "/usr/local/bin:/usr/bin:/bin" >> ${GITHUB_PATH}
         else
-          echo "::add-path::/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin"
+          echo "/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin" >> ${GITHUB_PATH}
         fi
 
     - name: Test uninstalling GitHub Actions Homebrew


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> Action and workflow authors who are setting environment variables via stdout should update any usage of the set-env and add-path workflow commands to use the new environment files.