### PR TITLE
Improved no_usable_ruby() test

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -221,13 +221,11 @@ test_ruby () {
 
 no_usable_ruby() {
   local ruby_exec
-  IFS=$'\n' # Do word splitting on new lines only
-  for ruby_exec in $(which -a ruby); do
+  which -a ruby | while read -r ruby_exec; do
     if test_ruby "$ruby_exec"; then
       return 1
     fi
   done
-  IFS=$' \t\n' # Restore IFS to its default value
   return 0
 }
 


### PR DESCRIPTION
This version doesn't mess with IFS, so it's probably more robust, and definitely easier to understand.