### PR TITLE
Use sudo -v instead of sudo -l mkdir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,9 +68,9 @@ have_sudo_access() {
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
     if [[ -n "${args[*]-}" ]]; then
-      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null 
-  else
-      /usr/bin/sudo -v && /usr/bin/sudo -l mkdir &>/dev/null 
+      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null
+    else
+      /usr/bin/sudo -v && /usr/bin/sudo -l mkdir &>/dev/null
     fi
     HAVE_SUDO_ACCESS="$?"
   fi
@@ -289,7 +289,6 @@ else
     HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
   else
     trap exit SIGINT
-    # If allowed to run sudo for mkdir and required to provide sudo password: prompt:
     if ! /usr/bin/sudo -n -v &>/dev/null; then
       ohai "Select the Homebrew installation directory"
       echo "- ${tty_bold}Enter your password${tty_reset} to install to ${tty_underline}${HOMEBREW_PREFIX_DEFAULT}${tty_reset} (${tty_bold}recommended${tty_reset})"

--- a/install.sh
+++ b/install.sh
@@ -68,9 +68,9 @@ have_sudo_access() {
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
     if [[ -n "${args[*]-}" ]]; then
-      /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null
+      /usr/bin/sudo "${args[@]}" -v &>/dev/null
     else
-      /usr/bin/sudo -l mkdir &>/dev/null
+      /usr/bin/sudo -v &>/dev/null
     fi
     HAVE_SUDO_ACCESS="$?"
   fi
@@ -286,7 +286,7 @@ else
     HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
   else
     trap exit SIGINT
-    if [[ $(/usr/bin/sudo -n -l mkdir 2>&1) != *"mkdir"* ]]; then
+    if ! /usr/bin/sudo -n -v &>/dev/null; then
       ohai "Select the Homebrew installation directory"
       echo "- ${tty_bold}Enter your password${tty_reset} to install to ${tty_underline}${HOMEBREW_PREFIX_DEFAULT}${tty_reset} (${tty_bold}recommended${tty_reset})"
       echo "- ${tty_bold}Press Control-D${tty_reset} to install to ${tty_underline}$HOME/.linuxbrew${tty_reset}"

--- a/install.sh
+++ b/install.sh
@@ -67,26 +67,8 @@ have_sudo_access() {
   fi
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
-
-    if [[ -n "${args[*]-}" ]]; then
-      SUDO="/usr/bin/sudo ${args[*]}"
-    else
-      SUDO="/usr/bin/sudo"
-    fi
-
-    if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
-      ${SUDO} -l mkdir
-    else
-      # We ask for password on Linux with sudo -v
-      # to give options as shown in the
-      # 'Select the Homebrew installation folder'
-      # But first we check if the user is allowed to run mkdir with sudo.
-      # (It is possible that the user is only allowed
-      # to run a subset of commands with sudo, but not mkdir.)
-      ${SUDO} -l mkdir &>/dev/null && ${SUDO} -v
-    fi
+    /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null 
     HAVE_SUDO_ACCESS="$?"
-
   fi
 
   if [[ -z "${HOMEBREW_ON_LINUX-}" ]] && [[ "$HAVE_SUDO_ACCESS" -ne 0 ]]; then
@@ -304,7 +286,7 @@ else
   else
     trap exit SIGINT
     # If allowed to run sudo for mkdir and required to provide sudo password: prompt:
-    if /usr/bin/sudo -l mkdir &>/dev/null && ! /usr/bin/sudo -n -v &>/dev/null; then
+    if ! /usr/bin/sudo -n -v &>/dev/null; then
       ohai "Select the Homebrew installation directory"
       echo "- ${tty_bold}Enter your password${tty_reset} to install to ${tty_underline}${HOMEBREW_PREFIX_DEFAULT}${tty_reset} (${tty_bold}recommended${tty_reset})"
       echo "- ${tty_bold}Press Control-D${tty_reset} to install to ${tty_underline}$HOME/.linuxbrew${tty_reset}"

--- a/install.sh
+++ b/install.sh
@@ -66,19 +66,27 @@ have_sudo_access() {
     args=("-A")
   fi
 
-  if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
-      SUDO_TEST="-l mkdir"
-  else
-      SUDO_TEST="-v"
-  fi
-
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
+
     if [[ -n "${args[*]-}" ]]; then
-      /usr/bin/sudo "${args[@]}" "${SUDO_TEST}" &>/dev/null
+      SUDO="/usr/bin/sudo ${args[*]}"
     else
-      /usr/bin/sudo "${SUDO_TEST}" &>/dev/null
+      SUDO="/usr/bin/sudo"
+    fi
+
+    if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
+      ${SUDO} -l mkdir
+    else
+      # We ask for password on Linux with sudo -v
+      # to give options as shown in the
+      # 'Select the Homebrew installation folder'
+      # But first we check if the user is allowed to run mkdir with sudo.
+      # (It is possible that the user is only allowed
+      # to run a subset of commands with sudo, but not mkdir.)
+      ${SUDO} -l mkdir &>/dev/null && ${SUDO} -v
     fi
     HAVE_SUDO_ACCESS="$?"
+
   fi
 
   if [[ -z "${HOMEBREW_ON_LINUX-}" ]] && [[ "$HAVE_SUDO_ACCESS" -ne 0 ]]; then
@@ -292,7 +300,8 @@ else
     HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
   else
     trap exit SIGINT
-    if ! /usr/bin/sudo -n -v &>/dev/null; then
+    # If allowed to run sudo for mkdir and required to provide sudo password: prompt:
+    if /usr/bin/sudo -l mkdir &>/dev/null && ! /usr/bin/sudo -n -v &>/dev/null; then
       ohai "Select the Homebrew installation directory"
       echo "- ${tty_bold}Enter your password${tty_reset} to install to ${tty_underline}${HOMEBREW_PREFIX_DEFAULT}${tty_reset} (${tty_bold}recommended${tty_reset})"
       echo "- ${tty_bold}Press Control-D${tty_reset} to install to ${tty_underline}$HOME/.linuxbrew${tty_reset}"

--- a/install.sh
+++ b/install.sh
@@ -68,9 +68,14 @@ have_sudo_access() {
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
     if [[ -n "${args[*]-}" ]]; then
-      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null
+      SUDO="/usr/bin/sudo ${args[*]}"
     else
-      /usr/bin/sudo -v && /usr/bin/sudo -l mkdir &>/dev/null
+      SUDO="/usr/bin/sudo"
+    fi
+    if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
+      ${SUDO} -l mkdir &>/dev/null
+    else
+      ${SUDO} -v && ${SUDO} -l mkdir &>/dev/null
     fi
     HAVE_SUDO_ACCESS="$?"
   fi

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,11 @@ have_sudo_access() {
   fi
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
-    /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null 
+    if [[ -n "${args[*]-}" ]]; then
+      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null 
+  else
+      /usr/bin/sudo -v && /usr/bin/sudo -l mkdir &>/dev/null 
+    fi
     HAVE_SUDO_ACCESS="$?"
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -66,11 +66,17 @@ have_sudo_access() {
     args=("-A")
   fi
 
+  if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
+      SUDO_TEST="-l mkdir"
+  else
+      SUDO_TEST="-v"
+  fi
+
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
     if [[ -n "${args[*]-}" ]]; then
-      /usr/bin/sudo "${args[@]}" -v &>/dev/null
+      /usr/bin/sudo "${args[@]}" "${SUDO_TEST}" &>/dev/null
     else
-      /usr/bin/sudo -v &>/dev/null
+      /usr/bin/sudo "${SUDO_TEST}" &>/dev/null
     fi
     HAVE_SUDO_ACCESS="$?"
   fi


### PR DESCRIPTION
Install script does not prompt for password for user to make choice between root and non-root install. 

If you install homebrew you can at some point hit the question 

```
Select the Homebrew installation directory
Enter your password to install to..
Press Control-D to install to ...". 
```

However, the check to prompt this is `sudo -l mkdir`. The `-l` flag is according to the sudo manpage [1] a check if the user is *allowed* to run command mkdir with sudo rights. Either the user can do this, in which case the prompt is skipped. Or the user cannot do this, in which case the prompt is shown, but useless, since the user would not be able to give useful credentials anyway.

Instead you should be using the flag `-v` which is for checking credentials and *prompting when necessary*. You can use `sudo -n -v` to check if the user *at the moment* can execute sudo commands without interaction (`-n` makes this non-interactive.) And using the flag `-v` without `-n` to check for user credentials and *prompting when necessary*. In which case the prompt make sense and can be correctly skipped with CTRL-D (I have that tested). 

TLDR; `sudo -l mkdir` does not prompt for password. `sudo -v` will prompt for password. 

[1] https://linux.die.net/man/8/sudo