### PR TITLE
README: Make it more visible that Linux and macOS share an installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
-More installation information and options at https://docs.brew.sh/Installation.html.
+More installation information and options: https://docs.brew.sh/Installation.
 
 If running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homebrew (un)installer
 
-## Install Homebrew
+## Install Homebrew (on macOS or Linux)
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
@@ -8,9 +8,7 @@
 
 More installation information and options at https://docs.brew.sh/Installation.html.
 
-### Linux and Windows 10 Subsystem for Linux
-
-Install Homebrew on Linux and Windows 10 Subsystem for Linux: https://docs.brew.sh/Linuxbrew.
+If running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).
 
 ## Uninstall Homebrew
 


### PR DESCRIPTION
- I came here to get the command for the uninstall script for something, and noticed that the Linux and WSL instructions were oddly separate.  Also, the `Linuxbrew` docs site page links back to the homepage for the main install command, which is circular.
- Instead, add a note for the pre-requisite packages for Linux.
