### PR TITLE
test under WSL on Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,3 +53,50 @@ jobs:
       run: |
         bash uninstall.sh -d >/dev/null
         bash uninstall.sh -f >/dev/null
+        
+  tests-wsl:
+    strategy:
+      matrix:
+        os:
+        - windows-latest
+        wsl:
+        - Ubuntu-18.04
+    runs-on: ${{matrix.os}}
+    steps:
+    - name: Set up Git
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+        
+    - name: Set up Git repository
+      uses: actions/checkout@main
+      
+    - name: Set up Homebrew PATH
+      run: echo "/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin" >> ${GITHUB_PATH}
+      
+    - name: Set up WSL
+      uses: Vampire/setup-wsl@v1
+      with:
+        distribution: ${{matrix.wsl}}
+        use-cache: 'false'
+
+    - shell: wsl-bash {0}
+      name: Test install.sh
+      run: |
+        bash install.sh
+        brew install ack
+        bash uninstall.sh -f >/dev/null
+        bash install.sh
+
+    - shell: wsl-bash {0}
+      name: Install Shellcheck
+      run: brew install shellcheck
+
+    - shell: wsl-bash {0}
+      run: shellcheck *.sh
+
+    - shell: wsl-bash {0}
+      name: Test uninstalling newly installed Homebrew
+      run: |
+        bash uninstall.sh -d >/dev/null
+        bash uninstall.sh -f >/dev/null


### PR DESCRIPTION
To test behaviour mentioned in https://github.com/Homebrew/install/pull/341#issuecomment-733786001
where the installer gets stuck, probably waiting for user input.

I duplicated the steps, otherwise each step needs conditionals to detect WSL and pipe commands to it (default `bash` on Github Actions' Windows agent is actually Git/MSYS2 `bash`).

Status: WIP