### PR TITLE
Don't add -A to sudo when you don't use sudo.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,10 +117,10 @@ execute() {
 
 execute_sudo() {
   local -a args=("$@")
-  if [[ -n "${SUDO_ASKPASS-}" ]]; then
-    args=("-A" "${args[@]}")
-  fi
   if have_sudo_access; then
+    if [[ -n "${SUDO_ASKPASS-}" ]]; then
+      args=("-A" "${args[@]}")
+    fi
     ohai "/usr/bin/sudo" "${args[@]}"
     execute "/usr/bin/sudo" "${args[@]}"
   else


### PR DESCRIPTION
If you don't use `sudo`, you don't have to add -A to the arguments, even if SUDO_ASKPASS is set. 

This happens for example when you try to force a home user install with `export SUDO_ASKPASS=false`. 