### PR TITLE
Set a NONINTERACTIVE variable to prevent prompting for password.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -u
 
+# Check if script is run non-interactively (e.g. CI)
+# If it is run non-interactively we should not prompt for passwords.
+if [[ ! -t 0 ]] || [[ ! -t 1 ]] || [[ $SHLVL == 1 ]] || ! tty -s; then
+  NONINTERACTIVE=1
+fi
+
 # First check if the OS is Linux.
 if [[ "$(uname)" = "Linux" ]]; then
   HOMEBREW_ON_LINUX=1
@@ -61,6 +67,9 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
+  if [[ ! -z "${NONINTERACTIVE-}" ]]; then
+    return 0
+  fi
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
-  if [[ ! -z "${NONINTERACTIVE-}" ]]; then
+  if [[ -n "${NONINTERACTIVE-}" ]]; then
     return 0
   fi
   local -a args


### PR DESCRIPTION
Performs a few checks to see if we are running non-interactively (these checks can be extended if we know more checks, maybe some specific with CI? I don't have so much experience with CI). If this is the case, we don't prompt for a password. 
