### PR TITLE
execute_sudo: Fix when SUDO_ASKPASS without sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,10 +117,10 @@ execute() {
 
 execute_sudo() {
   local -a args=("$@")
-  if [[ -n "${SUDO_ASKPASS-}" ]]; then
-    args=("-A" "${args[@]}")
-  fi
   if have_sudo_access; then
+    if [[ -n "${SUDO_ASKPASS-}" ]]; then
+      args=("-A" "${args[@]}")
+    fi
     ohai "/usr/bin/sudo" "${args[@]}"
     execute "/usr/bin/sudo" "${args[@]}"
   else


### PR DESCRIPTION
Fix a bug when `SUDO_ASKPASS` is defined but `have_sudo_access` is false.
