### PR TITLE
Use sudo -v instead of sudo -l but preserve possibility to do non-interactive installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -u
 
 # Check if script is run non-interactively (e.g. CI)
 # If it is run non-interactively we should not prompt for passwords.
-if [[ ! -t 0 || ! -t 1 || $SHLVL == 1 ]] || ! tty -s; then
+if [[ ! -t 0 || -n "${CI-}" ]]; then
   NONINTERACTIVE=1
 fi
 
@@ -67,13 +67,11 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
-  if [[ -n "${NONINTERACTIVE-}" && -z "${SUDO_ASKPASS-}" ]]; then
-    return 0
-  fi
-
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")
+  elif [[ -n "${NONINTERACTIVE-}" ]]; then
+    args=("-n")
   fi
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
-  if [[ -n "${NONINTERACTIVE-}" ]]; then
+  if [[ -n "${NONINTERACTIVE-}" && -z "${SUDO_ASKPASS-}" ]]; then
     return 0
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -298,7 +298,10 @@ fi
 if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
  have_sudo_access
 else
-  if [[ -n "${CI-}" ]] || [[ -w "$HOMEBREW_PREFIX_DEFAULT" ]] || [[ -w "/home/linuxbrew" ]] || [[ -w "/home" ]]; then
+  if [[ -n "${NONINTERACTIVE-}" ]] ||
+     [[ -w "$HOMEBREW_PREFIX_DEFAULT" ]] ||
+     [[ -w "/home/linuxbrew" ]] ||
+     [[ -w "/home" ]]; then
     HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
   else
     trap exit SIGINT
@@ -479,7 +482,7 @@ if should_install_command_line_tools; then
   ohai "The Xcode Command Line Tools will be installed."
 fi
 
-if [[ -t 0 && -z "${CI-}" ]]; then
+if [[ -z "${NONINTERACTIVE-}" ]]; then
   wait_for_user
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -u
 
 # Check if script is run non-interactively (e.g. CI)
 # If it is run non-interactively we should not prompt for passwords.
-if [[ ! -t 0 ]] || [[ ! -t 1 ]] || [[ $SHLVL == 1 ]] || ! tty -s; then
+if [[ ! -t 0 || ! -t 1 || $SHLVL == 1 ]] || ! tty -s; then
   NONINTERACTIVE=1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,9 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
+  if [[ -n "${NONINTERACTIVE-}" ]]; then
+    return 0
+  fi
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")

--- a/install.sh
+++ b/install.sh
@@ -67,9 +67,6 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
-  # if [[ -n "${NONINTERACTIVE-}" ]]; then
-  #   return 0
-  # fi
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")
@@ -79,13 +76,14 @@ have_sudo_access() {
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
     if [[ -n "${args[*]-}" ]]; then
-        echo "HELLO RUN COMMAND with args"
-        echo THIS: "${args[@]}"
-      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir
-      echo "HAVE PRINTED ERROR"
-      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null
+      SUDO="/usr/bin/sudo ${args[*]}"
     else
-      /usr/bin/sudo -v && /usr/bin/sudo -l mkdir &>/dev/null
+      SUDO="/usr/bin/sudo"
+    fi
+    if [[ -n "${NONINTERACTIVE-}" ]]; then
+      ${SUDO} -l mkdir &>/dev/null
+  else
+      ${SUDO} -v && ${SUDO} -l mkdir &>/dev/null
     fi
     HAVE_SUDO_ACCESS="$?"
   fi

--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ have_sudo_access() {
     fi
     if [[ -n "${NONINTERACTIVE-}" ]]; then
       ${SUDO} -l mkdir &>/dev/null
-  else
+    else
       ${SUDO} -v && ${SUDO} -l mkdir &>/dev/null
     fi
     HAVE_SUDO_ACCESS="$?"

--- a/install.sh
+++ b/install.sh
@@ -78,9 +78,9 @@ have_sudo_access() {
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
     if [[ -n "${args[*]-}" ]]; then
-      /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null
+      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null
     else
-      /usr/bin/sudo -l mkdir &>/dev/null
+      /usr/bin/sudo -v && /usr/bin/sudo -l mkdir &>/dev/null
     fi
     HAVE_SUDO_ACCESS="$?"
   fi
@@ -299,7 +299,7 @@ else
     HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
   else
     trap exit SIGINT
-    if [[ $(/usr/bin/sudo -n -l mkdir 2>&1) != *"mkdir"* ]]; then
+    if ! /usr/bin/sudo -n -v &>/dev/null; then
       ohai "Select the Homebrew installation directory"
       echo "- ${tty_bold}Enter your password${tty_reset} to install to ${tty_underline}${HOMEBREW_PREFIX_DEFAULT}${tty_reset} (${tty_bold}recommended${tty_reset})"
       echo "- ${tty_bold}Press Control-D${tty_reset} to install to ${tty_underline}$HOME/.linuxbrew${tty_reset}"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -u
 
+# Check if script is run non-interactively (e.g. CI)
+# If it is run non-interactively we should not prompt for passwords.
+if [[ ! -t 0 ]] || [[ ! -t 1 ]] || [[ $SHLVL == 1 ]] || ! tty -s; then
+  NONINTERACTIVE=1
+fi
+
 # First check if the OS is Linux.
 if [[ "$(uname)" = "Linux" ]]; then
   HOMEBREW_ON_LINUX=1
@@ -61,6 +67,10 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
+  if [[ -n "${NONINTERACTIVE-}" ]]; then
+    return 0
+  fi
+
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")

--- a/install.sh
+++ b/install.sh
@@ -67,9 +67,9 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
-  if [[ -n "${NONINTERACTIVE-}" ]]; then
-    return 0
-  fi
+  # if [[ -n "${NONINTERACTIVE-}" ]]; then
+  #   return 0
+  # fi
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")
@@ -79,6 +79,10 @@ have_sudo_access() {
 
   if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
     if [[ -n "${args[*]-}" ]]; then
+        echo "HELLO RUN COMMAND with args"
+        echo THIS: "${args[@]}"
+      /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir
+      echo "HAVE PRINTED ERROR"
       /usr/bin/sudo "${args[@]}" -v && /usr/bin/sudo "${args[@]}" -l mkdir &>/dev/null
     else
       /usr/bin/sudo -v && /usr/bin/sudo -l mkdir &>/dev/null


### PR DESCRIPTION
This bring back in the changes of #341 but without the special check of MacOS. 

Instead check for non-interactive usage, which then in turn forces an install without having going to prompt for the password. (As done in #355.)

---

Additionally, if SUDO_ASKPASS is set in a non-interactive install, still try to make use of SUDO_ASKPASS, because

 1. You can provide the password with a helper program, if you have actually still *need* to provide the password, but want to do that non-interactively.

 2. But you can also make use of the `export SUDO_ASKPASS=false` trick to work and force a home folder installation.
