### PR TITLE
fixed root user pre-flight check to check $EUID

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -321,7 +321,7 @@ else
   HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
 fi
 
-if [[ "$UID" == "0" ]]; then
+if [[ "${EUID:-${UID}}" == "0" ]]; then
   abort "Don't run this as root!"
 elif [[ -d "$HOMEBREW_PREFIX" && ! -x "$HOMEBREW_PREFIX" ]]; then
   abort "$(cat <<EOABORT


### PR DESCRIPTION
The install script currently aborts if you run it as a user via su or similar from root because it checks `$UID` instead of `$EUID` which is more accurate of the currently executing user.

This patch attempts to use the correct `$EUID` and falls back to `$UID` (this is run in bash which should always have `$EUID`).