### PR TITLE
Fix noninteractive prefix selection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -298,11 +298,12 @@ fi
 if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
  have_sudo_access
 else
-  if [[ -n "${NONINTERACTIVE-}" ]] ||
-     [[ -w "$HOMEBREW_PREFIX_DEFAULT" ]] ||
-     [[ -w "/home/linuxbrew" ]] ||
-     [[ -w "/home" ]]; then
-    HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
+  if [[ -n "${NONINTERACTIVE-}" ]]; then
+    if have_sudo_access; then
+      HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
+    else
+      HOMEBREW_PREFIX="$HOME/.linuxbrew"
+    fi
   else
     trap exit SIGINT
     if ! /usr/bin/sudo -n -v &>/dev/null; then


### PR DESCRIPTION
Check if there is sudo access to pick HOMEBREW_PREFIX, otherwise, the script tries to create the directories in the homebrew user home regardless of whether you have sudo access or not.

This fixes an issue introduced by https://github.com/Homebrew/install/commit/6f37ca94af073c2971efbed8aa293322aa171f26#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f.

Before that commit, in noninteractive mode, the install script would show the directory selection options but it'd pick the current user's home directory when you don't have sudo access. After that commit, it always tries to create /home/linuxbrew regardless of whether you have sudo access or not.