### PR TITLE
Only fech brew master branch during installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -593,7 +593,7 @@ ohai "Downloading and installing Homebrew..."
   # ensure we don't munge line endings on checkout
   execute "git" "config" "core.autocrlf" "false"
 
-  execute "git" "fetch" "origin" "--force"
+  execute "git" "fetch" "origin" "master"
   execute "git" "fetch" "origin" "--tags" "--force"
 
   execute "git" "reset" "--hard" "origin/master"


### PR DESCRIPTION
There is no need to fetch all branches during the installation process, as we can see on line 599, only the master is being used.