### PR TITLE
Fix: using wrong HOMEBREW_PREFIX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -298,9 +298,9 @@ fi
 if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
  have_sudo_access
 else
-  if [[ -n "${NONINTERACTIVE-}" ]] ||
-     [[ -w "$HOMEBREW_PREFIX_DEFAULT" ]] ||
-     [[ -w "/home/linuxbrew" ]] ||
+  if [[ -n "${NONINTERACTIVE-}" ]] &&
+     [[ -w "$HOMEBREW_PREFIX_DEFAULT" ]] &&
+     [[ -w "/home/linuxbrew" ]] &&
      [[ -w "/home" ]]; then
     HOMEBREW_PREFIX="$HOMEBREW_PREFIX_DEFAULT"
   else


### PR DESCRIPTION
The comment in the file https://github.com/Homebrew/install/blob/master/install.sh#L17 specifically mention that it is possible to run linuxbrew in `~/.linuxbrew` 
However, it looks like https://github.com/Homebrew/install/commit/6f37ca94af073c2971efbed8aa293322aa171f26 broke this behaviour. 

I believe this is because, once you run it NONITERACTIVE, the IF statement is True, causing it to branch into the wrong path.
This fixes that.

Also relates to https://github.com/Homebrew/install/issues/369