### PR TITLE
Fix: Xcode Command Line Tools checking

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,8 @@ should_install_command_line_tools() {
   fi
 
   if version_gt "$macos_version" "10.13"; then
-    ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]]
+    ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]] &&
+      ! [[ -e "/Applications/Xcode.app/Contents/Developer/usr/bin/git" ]]
   else
     ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]] ||
       ! [[ -e "/usr/include/iconv.h" ]]


### PR DESCRIPTION
Command Line Tools installation is executed even though Xcode 12 is installed.
Xcode 12 includes Command Line Tools.
It's installed in `/Applications/Xcode.app/Contents/Developer`.
So I added IF statement to check whether Command Line Tools for Xcode is exists.
It occurred in macOS Catalina.