### PR TITLE
Added Default prefix for MacOS on ARM in Uninstaller script

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -42,7 +42,6 @@ opt_skip_cache_and_logs=""
 failed=false
 
 un=$(uname)
-unm=$(uname -m)
 case "$un" in
   Linux)
     ostype=linux
@@ -50,7 +49,7 @@ case "$un" in
   ;;
   Darwin)
     ostype=macos
-    if [[ "$unm" == "arm64" ]]; then
+    if [[ "$(uname -m)" == "arm64" ]]; then
       homebrew_prefix_default=/opt/homebrew
     else
       homebrew_prefix_default=/usr/local

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -42,6 +42,7 @@ opt_skip_cache_and_logs=""
 failed=false
 
 un=$(uname)
+unm=$(uname -m)
 case "$un" in
   Linux)
     ostype=linux
@@ -49,7 +50,11 @@ case "$un" in
   ;;
   Darwin)
     ostype=macos
-    homebrew_prefix_default=/usr/local
+    if [[ "$unm" == "arm64" ]]; then
+      homebrew_prefix_default=/opt/homebrew
+    else
+      homebrew_prefix_default=/usr/local
+    fi
     realpath() {
       cd "$(dirname "$1")" && echo "$(pwd -P)/$(basename "$1")"
     }


### PR DESCRIPTION
Corrected Uninstall script for detecting location of homebrew automatically in M1 Macs.

Tried Multiple times and confirmed to be working.