### PR TITLE
install.sh: show shellenv instructions on Apple M1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -656,7 +656,7 @@ echo "- Run \`brew help\` to get started"
 echo "- Further documentation: "
 echo "    ${tty_underline}https://docs.brew.sh${tty_reset}"
 
-if [[ -n "${HOMEBREW_ON_LINUX-}" ]]; then
+if [[ "$UNAME_MACHINE" == "arm64" ]] || [[ -n "${HOMEBREW_ON_LINUX-}" ]]; then
   case "$SHELL" in
     */bash*)
       if [[ -r "$HOME/.bash_profile" ]]; then
@@ -672,7 +672,18 @@ if [[ -n "${HOMEBREW_ON_LINUX-}" ]]; then
       shell_profile="$HOME/.profile"
       ;;
   esac
+fi
 
+# HOMEBREW_PREFIX is not in PATH on ARM macOS, so remind users to set up their shell
+if [[ -z "${HOMEBREW_ON_LINUX-}" ]] && [[ "$UNAME_MACHINE" == "arm64" ]]; then
+  cat <<EOS
+- Add Homebrew to your ${tty_bold}PATH${tty_reset} in ${tty_underline}${shell_profile}${tty_reset}:
+    echo 'eval \$(${HOMEBREW_PREFIX}/bin/brew shellenv)' >> ${shell_profile}
+    eval \$(${HOMEBREW_PREFIX}/bin/brew shellenv)
+EOS
+fi
+
+if [[ -n "${HOMEBREW_ON_LINUX-}" ]]; then
   echo "- Install the Homebrew dependencies if you have sudo access:"
 
   if [[ $(command -v apt-get) ]]; then


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/10191.

Ok, this seems to work. At the end of the install, it should show
```
==> Next steps:
- Run `brew help` to get started
- Further documentation:
    https://docs.brew.sh
- Add Homebrew to your PATH in /Users/carlocab/.zprofile:
    echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> /Users/carlocab/.zprofile
    eval $(/opt/homebrew/bin/brew shellenv)
```