### PR TITLE
add functionality to lock installation to specific git refs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -614,7 +614,7 @@ ohai "Downloading and installing Homebrew..."
   execute "git" "fetch" "--force" "origin"
   execute "git" "fetch" "--force" "--tags" "origin"
 
-  execute "git" "reset" "--hard" "origin/master"
+  execute "git" "reset" "--hard" "${HOMEBREW_BREW_GIT_REF:-origin/master}"
 
   if [[ "${HOMEBREW_REPOSITORY}" != "${HOMEBREW_PREFIX}" ]]; then
     execute "ln" "-sf" "${HOMEBREW_REPOSITORY}/bin/brew" "${HOMEBREW_PREFIX}/bin/brew"
@@ -632,7 +632,7 @@ ohai "Downloading and installing Homebrew..."
       execute "git" "config" "core.autocrlf" "false"
       execute "git" "fetch" "--force" "origin" "refs/heads/master:refs/remotes/origin/master"
       execute "git" "remote" "set-head" "origin" "--auto" >/dev/null
-      execute "git" "reset" "--hard" "origin/master"
+      execute "git" "reset" "--hard" "${HOMEBREW_CORE_GIT_REF:-origin/master}"
 
       cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
     ) || exit 1


### PR DESCRIPTION
rationalé: determinism.

I'm installing homebrew/linuxbrew in the CI, and right after installing brew, I do reset to specific git refs of brew/core tap. But that's not enough when installing with brewed ruby/git/curl, which would pick up formulas/bottles as per origin/master, which in turn means that the end state, after running `brew install` commands, is some packages are newer than they should be.

Some documentation would be nice, but maybe not. Up to you. Let me know.