### PR TITLE
install.sh: tell the user that we're going to run sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,8 +85,6 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
-  echo "We're testing for sudo access. You may be prompted for your password."
-
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")
@@ -305,6 +303,8 @@ You must install cURL before installing Homebrew. See:
 EOABORT
 )"
 fi
+
+echo "We're testing for sudo access. You may be prompted for your password."
 
 if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
   have_sudo_access

--- a/install.sh
+++ b/install.sh
@@ -304,6 +304,7 @@ EOABORT
 )"
 fi
 
+# shellcheck disable=SC2016
 ohai 'Checking for `sudo` access (which may request your password).'
 
 if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,8 @@ tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
 have_sudo_access() {
+  echo "We're testing for sudo access. You may be prompted for your password."
+
   local -a args
   if [[ -n "${SUDO_ASKPASS-}" ]]; then
     args=("-A")

--- a/install.sh
+++ b/install.sh
@@ -304,7 +304,7 @@ EOABORT
 )"
 fi
 
-echo "We're testing for sudo access. You may be prompted for your password."
+ohai 'Checking for `sudo` access (which may request your password).'
 
 if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
   have_sudo_access


### PR DESCRIPTION
This is a pretty minor change: someone I work with mentioned being surprised that the Homebrew install script immediately prompted them for a password (without telling them which password) with no other information, so this just tells the user that we're testing for `sudo` and that they *may* get prompted.

