### PR TITLE
Update HAVE_SUDO_ACCESS check's error message for macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ have_sudo_access() {
   fi
 
   if [[ -z "${HOMEBREW_ON_LINUX-}" ]] && [[ "$HAVE_SUDO_ACCESS" -ne 0 ]]; then
-    abort "Need sudo access on macOS (e.g. the user $USER to be an Administrator)!"
+    abort "Need sudo access on macOS (e.g. the user $USER needs to be an Administrator)!"
   fi
 
   return "$HAVE_SUDO_ACCESS"


### PR DESCRIPTION
Just a simple string change. I noticed a missing word while running a NONINTERACTIVE install without having `sudo` access.