### PR TITLE
Read Homebrew remote URLs from environment variables and prompt for non-default values

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,8 +83,8 @@ jobs:
 
       - run: /bin/bash uninstall.sh -f >/dev/null
 
-      - name: Install Homebrew with arguments
-        # Use Git Protocol for default remotes
+      - name: Install Homebrew with non-default remotes
+        # Use the default remotes but with Git Protocol
         run: |
           HOMEBREW_BREW_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/brew"
           if [ "${{ runner.os }}" = "macOS" ]; then
@@ -92,11 +92,15 @@ jobs:
           else
             HOMEBREW_CORE_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/linuxbrew-core"
           fi
-          /bin/bash -c "$(cat install.sh)" \
-            --brew-git-remote "${HOMEBREW_BREW_DEFAULT_GIT_REMOTE/%https/git}" \
-            --core-git-remote "${HOMEBREW_CORE_DEFAULT_GIT_REMOTE/%https/git}"
+          export HOMEBREW_BREW_GIT_REMOTE="${HOMEBREW_BREW_DEFAULT_GIT_REMOTE/%https/git}"
+          export HOMEBREW_CORE_GIT_REMOTE="${HOMEBREW_CORE_DEFAULT_GIT_REMOTE/%https/git}"
+          /bin/bash -c "$(cat install.sh)"
 
-      - run: /bin/bash uninstall.sh -f >/dev/null
+      - run: brew config
+
+      - run: |
+          /bin/bash uninstall.sh -f >/dev/null
+          unset HOMEBREW_{BREW,CORE}{,_DEFAULT}_GIT_REMOTE
 
       - run: /bin/bash -c "$(cat install.sh)"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,21 @@ jobs:
 
       - run: /bin/bash uninstall.sh -f >/dev/null
 
+      - name: Install Homebrew with arguments
+        # Use Git Protocol for default remotes
+        run: |
+          HOMEBREW_BREW_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/brew"
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            HOMEBREW_CORE_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/homebrew-core"
+          else
+            HOMEBREW_CORE_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/linuxbrew-core"
+          fi
+          /bin/bash -c "$(cat install.sh)" \
+            --brew-git-remote "${HOMEBREW_BREW_DEFAULT_GIT_REMOTE/%https/git}" \
+            --core-git-remote "${HOMEBREW_CORE_DEFAULT_GIT_REMOTE/%https/git}"
+
+      - run: /bin/bash uninstall.sh -f >/dev/null
+
       - run: /bin/bash -c "$(cat install.sh)"
 
       - name: Uninstall and reinstall with sudo NOPASSWD

--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ More installation information and options: https://docs.brew.sh/Installation.
 
 If running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).
 
+You can set `HOMEBREW_BREW_GIT_REMOTE` and/or `HOMEBREW_CORE_GIT_REMOTE` in your shell environment to use custom Git mirrors to speed up brew update and brew tap.
+
+```bash
+export HOMEBREW_BREW_GIT_REMOTE="..."  # put your mirror URL of Homebrew/brew Git remote here
+export HOMEBREW_CORE_GIT_REMOTE="..."  # put your mirror URL of Homebrew/core Git remote here
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
+
+| Variable                 | Default                                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| HOMEBREW_BREW_GIT_REMOTE | macOS / Linux: https://github.com/Homebrew/brew                                                        |
+| HOMEBREW_CORE_GIT_REMOTE | macOS: https://github.com/Homebrew/homebrew-core<br/>Linux: https://github.com/Homebrew/linuxbrew-core |
+
+The default Git remote will be used if the corresponding environment variable is unset.
+
 ## Uninstall Homebrew
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,18 +10,13 @@ More installation information and options: https://docs.brew.sh/Installation.
 
 If running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).
 
-You can set `HOMEBREW_BREW_GIT_REMOTE` and/or `HOMEBREW_CORE_GIT_REMOTE` in your shell environment to use custom Git mirrors to speed up brew update and brew tap.
+You can set `HOMEBREW_BREW_GIT_REMOTE` and/or `HOMEBREW_CORE_GIT_REMOTE` in your shell environment to use geolocalized Git mirrors to speed up Homebrew's installation with this script and, after installation, `brew update`.
 
 ```bash
-export HOMEBREW_BREW_GIT_REMOTE="..."  # put your mirror URL of Homebrew/brew Git remote here
-export HOMEBREW_CORE_GIT_REMOTE="..."  # put your mirror URL of Homebrew/core Git remote here
+export HOMEBREW_BREW_GIT_REMOTE="..."  # put your Git mirror of Homebrew/brew here
+export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebrew-core here
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
-
-| Variable                 | Default                                                                                                |
-| ------------------------ | ------------------------------------------------------------------------------------------------------ |
-| HOMEBREW_BREW_GIT_REMOTE | macOS / Linux: https://github.com/Homebrew/brew                                                        |
-| HOMEBREW_CORE_GIT_REMOTE | macOS: https://github.com/Homebrew/homebrew-core<br/>Linux: https://github.com/Homebrew/linuxbrew-core |
 
 The default Git remote will be used if the corresponding environment variable is unset.
 

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ if [[ -z "${HOMEBREW_ON_LINUX-}" ]]; then
     HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
   fi
   HOMEBREW_CACHE="${HOME}/Library/Caches/Homebrew"
-  HOMEBREW_CORE_GIT_REMOTE="https://github.com/Homebrew/homebrew-core"
+  HOMEBREW_CORE_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/homebrew-core"
 
   STAT="stat -f"
   CHOWN="/usr/sbin/chown"
@@ -50,7 +50,7 @@ else
   # and ~/.linuxbrew (which is unsupported) if run interactively.
   HOMEBREW_PREFIX_DEFAULT="/home/linuxbrew/.linuxbrew"
   HOMEBREW_CACHE="${HOME}/.cache/Homebrew"
-  HOMEBREW_CORE_GIT_REMOTE="https://github.com/Homebrew/linuxbrew-core"
+  HOMEBREW_CORE_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/linuxbrew-core"
 
   STAT="stat --printf"
   CHOWN="/bin/chown"
@@ -58,7 +58,10 @@ else
   GROUP="$(id -gn)"
   TOUCH="/bin/touch"
 fi
-HOMEBREW_BREW_GIT_REMOTE="https://github.com/Homebrew/brew"
+HOMEBREW_BREW_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/brew"
+
+HOMEBREW_BREW_GIT_REMOTE="${HOMEBREW_BREW_GIT_REMOTE:-"${HOMEBREW_BREW_DEFAULT_GIT_REMOTE}"}"
+HOMEBREW_CORE_GIT_REMOTE="${HOMEBREW_CORE_GIT_REMOTE:-"${HOMEBREW_CORE_DEFAULT_GIT_REMOTE}"}"
 
 # TODO: bump version when new macOS is released or announced
 MACOS_NEWEST_UNSUPPORTED="12.0"

--- a/install.sh
+++ b/install.sh
@@ -316,8 +316,8 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 # Use the default remotes if not specified.
-HOMEBREW_BREW_GIT_REMOTE="${HOMEBREW_BREW_GIT_REMOTE:-"${HOMEBREW_BREW_DEFAULT_GIT_REMOTE}"}"
-HOMEBREW_CORE_GIT_REMOTE="${HOMEBREW_CORE_GIT_REMOTE:-"${HOMEBREW_CORE_DEFAULT_GIT_REMOTE}"}"
+export HOMEBREW_BREW_GIT_REMOTE="${HOMEBREW_BREW_GIT_REMOTE:-"${HOMEBREW_BREW_DEFAULT_GIT_REMOTE}"}"
+export HOMEBREW_CORE_GIT_REMOTE="${HOMEBREW_CORE_GIT_REMOTE:-"${HOMEBREW_CORE_DEFAULT_GIT_REMOTE}"}"
 
 if [[ -n "${HOMEBREW_ON_LINUX-}" ]] && no_usable_ruby && outdated_glibc
 then
@@ -557,6 +557,15 @@ if should_install_command_line_tools; then
   ohai "The Xcode Command Line Tools will be installed."
 fi
 
+if [[ "$HOMEBREW_BREW_DEFAULT_GIT_REMOTE" != "$HOMEBREW_BREW_GIT_REMOTE" ]]; then
+  ohai "HOMEBREW_BREW_GIT_REMOTE is set to a non-default URL:"
+  echo "${tty_underline}${HOMEBREW_BREW_GIT_REMOTE}${tty_reset} will be used for Homebrew/brew Git remote."
+fi
+if [[ "$HOMEBREW_CORE_DEFAULT_GIT_REMOTE" != "$HOMEBREW_CORE_GIT_REMOTE" ]]; then
+  ohai "HOMEBREW_CORE_GIT_REMOTE is set to a non-default URL:"
+  echo "${tty_underline}${HOMEBREW_CORE_GIT_REMOTE}${tty_reset} will be used for Homebrew/core Git remote."
+fi
+
 if [[ -z "${NONINTERACTIVE-}" ]]; then
   wait_for_user
 fi
@@ -663,10 +672,6 @@ ohai "Downloading and installing Homebrew..."
 (
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
 
-  if [[ "$HOMEBREW_BREW_DEFAULT_GIT_REMOTE" != "$HOMEBREW_BREW_GIT_REMOTE" ]]; then
-    echo "HOMEBREW_BREW_GIT_REMOTE set: using $HOMEBREW_BREW_GIT_REMOTE for Homebrew/brew Git remote URL."
-  fi
-
   # we do it in four steps to avoid merge errors when reinstalling
   execute "git" "init" "-q"
 
@@ -691,10 +696,6 @@ ohai "Downloading and installing Homebrew..."
     (
       execute "/bin/mkdir" "-p" "${HOMEBREW_CORE}"
       cd "${HOMEBREW_CORE}" >/dev/null || return
-
-      if [[ "$HOMEBREW_CORE_DEFAULT_GIT_REMOTE" != "$HOMEBREW_CORE_GIT_REMOTE" ]]; then
-        echo "HOMEBREW_CORE_GIT_REMOTE set: using $HOMEBREW_CORE_GIT_REMOTE for Homebrew/core Git remote URL."
-      fi
 
       execute "git" "init" "-q"
       execute "git" "config" "remote.origin.url" "${HOMEBREW_CORE_GIT_REMOTE}"

--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,8 @@ abort() {
   exit 1
 }
 
-# BASH is required
 if [ -z "${BASH_VERSION:-}" ]; then
-  abort "BASH is required to interpret this script."
+  abort "Bash is required to interpret this script."
 fi
 
 # Check if script is run non-interactively (e.g. CI)

--- a/install.sh
+++ b/install.sh
@@ -609,6 +609,10 @@ ohai "Downloading and installing Homebrew..."
 (
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
 
+  if [[ "$HOMEBREW_BREW_DEFAULT_GIT_REMOTE" != "$HOMEBREW_BREW_GIT_REMOTE" ]]; then
+    echo "HOMEBREW_BREW_GIT_REMOTE set: using $HOMEBREW_BREW_GIT_REMOTE for Homebrew/brew Git remote URL."
+  fi
+
   # we do it in four steps to avoid merge errors when reinstalling
   execute "git" "init" "-q"
 
@@ -633,6 +637,10 @@ ohai "Downloading and installing Homebrew..."
     (
       execute "/bin/mkdir" "-p" "${HOMEBREW_CORE}"
       cd "${HOMEBREW_CORE}" >/dev/null || return
+
+      if [[ "$HOMEBREW_CORE_DEFAULT_GIT_REMOTE" != "$HOMEBREW_CORE_GIT_REMOTE" ]]; then
+        echo "HOMEBREW_CORE_GIT_REMOTE set: using $HOMEBREW_CORE_GIT_REMOTE for Homebrew/core Git remote URL."
+      fi
 
       execute "git" "init" "-q"
       execute "git" "config" "remote.origin.url" "${HOMEBREW_CORE_GIT_REMOTE}"

--- a/install.sh
+++ b/install.sh
@@ -270,17 +270,17 @@ outdated_glibc() {
 usage() {
   cat <<EOS
 Homebrew Installer
-Usage: /bin/bash install.sh [--help] [--brew-git-remote URL] [--core-git-remote URL]
+Usage: /bin/bash install.sh [--help] [--brew-git-remote [URL]] [--core-git-remote [URL]]
 
 This script installs Homebrew, the missing package manager for macOS (or Linux).
 
 Options:
   -b, --brew-git-remote=URL   Use this URL as the Homebrew/brew git remote.
-                              Default: ${HOMEBREW_BREW_DEFAULT_GIT_REMOTE}.
-
+                              If no argument is given, the default remote is used.
+                              Default: ${tty_underline}${HOMEBREW_BREW_DEFAULT_GIT_REMOTE}${tty_reset}.
   -c, --core-git-remote=URL   Use this URL as the Homebrew/homebrew-core git remote.
-                              Default: ${HOMEBREW_CORE_DEFAULT_GIT_REMOTE}.
-
+                              If no argument is given, the default remote is used.
+                              Default: ${tty_underline}${HOMEBREW_CORE_DEFAULT_GIT_REMOTE}${tty_reset}.
   -h, --help                  Show this help message and exit.
 EOS
   exit "${1:-0}"

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 set -u
 
+abort() {
+  printf "%s\n" "$@"
+  exit 1
+}
+
+# BASH is required
+if [ -z "${BASH_VERSION:-}" ]; then
+  abort "BASH is required to interpret this script."
+fi
+
 # Check if script is run non-interactively (e.g. CI)
 # If it is run non-interactively we should not prompt for passwords.
 if [[ ! -t 0 || -n "${CI-}" ]]; then
   NONINTERACTIVE=1
 fi
-
-abort() {
-  printf "%s\n" "$1"
-  exit 1
-}
 
 # First check OS.
 OS="$(uname)"
@@ -284,13 +289,12 @@ EOS
 # Parse remote URLs of Homebrew repositories from command line arguments if presented.
 unset HOMEBREW_{BREW,CORE}_GIT_REMOTE  # unset variables from environment at first
 # The value of the script basename in different situations:
-#   - shell name (usually "bash" or "sh"): invoked by `SHELL -c` with no arguments.
-#   - script name "install.sh":            invoked by SHELL directly.
-#   - otherwise:                           invoked by `SHELL -c` with at least one argument.
-SHELL_NAME="$(ps -p $$ -oucomm= | tr -d ' ')"
-if [[ "$(basename -- "$0")" != "${SHELL_NAME}" &&
-      "$(basename -- "$0")" != "install.sh" ]]; then
-  # The script is invoked by `SHELL -c "$(cat install.sh)" ...` with at least one argument.
+#   - "bash":       invoked by `bash -c` with no arguments.
+#   - "install.sh": invoked by bash directly.
+#   - otherwise:    invoked by `bash -c` with at least one argument.
+if ! [[ "$(basename -- "$0")" =~ ^(ba)?sh$ ||
+        "$(basename -- "$0")" == "install.sh" ]]; then
+  # The script is invoked by `bash -c "$(cat install.sh)" ...` with at least one argument.
   # Unshift the first argument back to the argument list
   set -- "$0" "$@"
 fi


### PR DESCRIPTION
The current install script hardcodes `HOMEBREW_{BREW,CORE}_GIT_REMOTE`. Users can only get Homebrew from GitHub during the first installation. Currently the size of `homebrew-core` repo is up to  371.09 MB. Sometimes it can be really slow during the installation process.

Only after the installation is complete, the user can change the remote of the repositories.
```bash
# Users get Homebrew from GitHub
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"

# Users can change the remote after long time for `git clone`
export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/brew.git"
export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/homebrew-core.git"
brew update
```

Currently, I hack the install script when getting Homebrew. I hope it can be officially supported.
```bash
# Before
export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/brew.git"
export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/homebrew-core.git"
/bin/bash -c "$(
    curl -fsSL https://github.com/Homebrew/install/raw/master/install.sh |
    sed -E 's#^(\s*)(HOMEBREW_(BREW|CORE)_GIT_REMOTE)=(.*)$#\1\2="${\2:-\4}"#'
)"

# After
export HOMEBREW_BREW_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/brew.git"
export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/homebrew-core.git"
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
```
