### PR TITLE
Replace references to master with HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Install Homebrew (on macOS or Linux)
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 More installation information and options: https://docs.brew.sh/Installation.
@@ -15,7 +15,7 @@ You can set `HOMEBREW_BREW_GIT_REMOTE` and/or `HOMEBREW_CORE_GIT_REMOTE` in your
 ```bash
 export HOMEBREW_BREW_GIT_REMOTE="..."  # put your Git mirror of Homebrew/brew here
 export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebrew-core here
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 The default Git remote will be used if the corresponding environment variable is unset.
@@ -23,7 +23,7 @@ The default Git remote will be used if the corresponding environment variable is
 ## Uninstall Homebrew
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 ```
 
 Download the uninstall script and run `/bin/bash uninstall.sh --help` to view more uninstall options.

--- a/install
+++ b/install
@@ -3,8 +3,8 @@
 STDERR.print <<EOS
 Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
 Bash. Please migrate to the following command:
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 EOS
 
-Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
+Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'

--- a/uninstall
+++ b/uninstall
@@ -3,8 +3,8 @@
 STDERR.print <<EOS
 Warning: The Ruby Homebrew uninstaller is now deprecated and has been rewritten in
 Bash. Please migrate to the following command:
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 
 EOS
 
-Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"' + ' uninstall ' +  ARGV.join(" ")
+Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"' + ' uninstall ' +  ARGV.join(" ")

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -227,7 +227,7 @@ fi
 if [[ -s $HOMEBREW_REPOSITORY/.gitignore ]]; then
   gitignore=$(<"$HOMEBREW_REPOSITORY/.gitignore")
 else
-  gitignore=$(curl -fsSL https://raw.githubusercontent.com/Homebrew/brew/master/.gitignore)
+  gitignore=$(curl -fsSL https://raw.githubusercontent.com/Homebrew/brew/HEAD/.gitignore)
 fi
 [[ -n $gitignore ]] || abort "Failed to fetch Homebrew .gitignore!"
 


### PR DESCRIPTION
We use `HEAD` in the install instructions on brew.sh, so we may as well
do the same here.

There are still some references to `master` in `install.sh`, but I don't
think those can be changed.