### PR TITLE
fix typo after brew cask deprecations

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,7 +12,7 @@ contact_links:
   about: On macOS/Mac OS X? Having a `brew` problem with a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/homebrew-core (the macOS core tap/repository).
 - name: New issue on Homebrew/homebrew-cask
   url: https://github.com/Homebrew/homebrew-cask/issues/new/choose
-  about: Having a `brew cask` problem? Report it to Homebrew/homebrew-cask (the cask tap/repository).
+  about: Having a `brew --cask` problem? Report it to Homebrew/homebrew-cask (the cask tap/repository).
 - name: New issue on Homebrew/linuxbrew-core
   url: https://github.com/Homebrew/linuxbrew-core/issues/new/choose
   about: On Linux? Having a `brew` problem with a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/linuxbrew-core (the Linux core tap/repository).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,9 @@
 blank_issues_enabled: false
 
 contact_links:
-- name: Get help on Discourse
-  url: https://discourse.brew.sh
-  about: Have a question? Not sure if your issue affects everyone reproducibly? The quickest way to get help is on Homebrew's Discourse!
+- name: Get help in GitHub Discussions
+  url: https://github.com/Homebrew/discussions/discussions
+  about: Have a question? Not sure if your issue affects everyone reproducibly? The quickest way to get help is on Homebrew's GitHub Discussions!
 - name: New issue on Homebrew/brew
   url: https://github.com/Homebrew/brew/issues/new/choose
   about: Having a `brew` problem that's not from a `brew install` or `brew upgrade` of a single formula/package?


### PR DESCRIPTION
Fixing typo after `brew cask` commands were deprecated