### PR TITLE
Show actual default prefix in uninstall.sh --help

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -169,7 +169,7 @@ usage() {
   cat <<EOS
 Homebrew Uninstaller
 Usage: $0 [options]
-    -p, --path=PATH  Sets Homebrew prefix. Defaults to /usr/local.
+    -p, --path=PATH  Sets Homebrew prefix. Defaults to ${homebrew_prefix_default}.
         --skip-cache-and-logs
                      Skips removal of HOMEBREW_CACHE and HOMEBREW_LOGS.
     -f, --force      Uninstall without prompting.


### PR DESCRIPTION
I use Homebrew on an M1 Mac, and today I noticed that the last package I used from x86_64 Homebrew was now bottled for arm64. 🎉 I found the Homebrew installer, ran `uninstall.sh --help`, and it showed me that by default it’d uninstall the Homebrew in `/usr/local`. Just what I wanted!

I then ran and hastily approved the actual uninstall — and only noticed belatedly that it was actually purging `/opt/homebrew` 😅. Fortunately I keep a `Brewfile` so getting things reinstalled wasn’t too difficult, but this PR will update `--help` to show the actual `$homebrew_prefix_default` detected by the script.