### PR TITLE
install.sh: search PATH for usable cURL/Git on Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -296,6 +296,7 @@ find_tool() {
   if [[ $# -ne 1 ]]; then
     return
   fi
+
   local executable
   IFS=$'\n' # Do word splitting on new lines only
   for executable in $(which -a "$1" 2>/dev/null); do


### PR DESCRIPTION
**Changes that affect Linux only**

1. New `find_tool` function (based on old `no_usable_ruby`)
   searches for the specified program in PATH.
   This function automatically calls `test_${tool_name}` function that
   must verify that the tool satisfies Homebrew requirements. Example:

   ```sh
   g_tool=$(find_tool git)
   c_tool=$(find_tool curl)
   r_tool=$(find_tool ruby)
   ```
2. New `test_curl` and `test_git` functions (which are similar to `test_ruby`)
3. Rewrote `no_usable_ruby` function to take advantage of the `find_tool` function
4. Search PATH for usable cURL and Git. If identified tools are not in
   `/usr/bin/`, automatically set `HOMEBREW_{GIT,CURL}_PATH` and `HOMEBREW_DEVELOPER`.

**Changes that affect both Linux and macOS**

Alter the warning message about `HOMEBREW_PREFIX/bin` not being in `PATH`
and instruct users to look at the 'Next steps' section below.

Addresses #554 