### PR TITLE
install.sh: show prompt messages before asking password

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -341,7 +341,7 @@ if [[ -z "${USER-}" ]]; then
 fi
 
 # Invalidate sudo timestamp before exiting (if it wasn't active before).
-if have_sudo_access && ! /usr/bin/sudo -n -v 2>/dev/null; then
+if [[ -x /usr/bin/sudo ]] && ! /usr/bin/sudo -n -v 2>/dev/null; then
   trap '/usr/bin/sudo -k' EXIT
 fi
 


### PR DESCRIPTION
Function `have_sudo_access` executes before any prompt message showing up.

![Screenshot](https://user-images.githubusercontent.com/16078332/131636385-1ac5f5aa-77c8-42cb-9603-fdc7fd05e4f1.png)
