### PR TITLE
install.sh: use relative path for symlinks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -742,7 +742,11 @@ ohai "Downloading and installing Homebrew..."
   execute "git" "reset" "--hard" "origin/master"
 
   if [[ "${HOMEBREW_REPOSITORY}" != "${HOMEBREW_PREFIX}" ]]; then
-    execute "ln" "-sf" "${HOMEBREW_REPOSITORY}/bin/brew" "${HOMEBREW_PREFIX}/bin/brew"
+    if [[ "${HOMEBREW_REPOSITORY}" == "${HOMEBREW_PREFIX}/Homebrew" ]]; then
+      execute "ln" "-sf" "../Homebrew/bin/brew" "${HOMEBREW_PREFIX}/bin/brew"
+    else  # absolute path as fallback option (we probably never reach here)
+      execute "ln" "-sf" "${HOMEBREW_REPOSITORY}/bin/brew" "${HOMEBREW_PREFIX}/bin/brew"
+    fi
   fi
 
   if [[ ! -d "${HOMEBREW_CORE}" ]]; then


### PR DESCRIPTION
Change absolute path to relative path for `brew` executable on Linux and ARM64 macOS. This modification allows user to move their brew installation elsewhere after then.