### PR TITLE
install.sh: remove dependency for `which` command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -264,8 +264,7 @@ file_not_grpowned() {
 
 # Please sync with 'test_ruby()' in 'Library/Homebrew/utils/ruby.sh' from Homebrew/brew repository.
 test_ruby() {
-  if [[ ! -x $1 ]]
-  then
+  if [[ ! -x "$1" ]]; then
     return 1
   fi
 
@@ -275,7 +274,7 @@ test_ruby() {
 }
 
 test_curl() {
-  if [[ ! -x $1 ]]; then
+  if [[ ! -x "$1" ]]; then
     return 1
   fi
 
@@ -286,7 +285,7 @@ test_curl() {
 }
 
 test_git() {
-  if [[ ! -x $1 ]]; then
+  if [[ ! -x "$1" ]]; then
     return 1
   fi
 
@@ -301,15 +300,16 @@ find_tool() {
     return
   fi
 
-  local executable
-  IFS=$'\n' # Do word splitting on new lines only
-  for executable in $(which -a "$1" 2>/dev/null); do
-    if "test_$1" "$executable"; then
-      echo "$executable"
+  # Search all PATH entries (remove dependency for `which` command)
+  local executable entries entry
+  readarray -d ':' -t entries <<< "$PATH"  # as we are using Bash, use readarray
+  for entry in "${entries[@]}"; do
+    executable="${entry}/$1"
+    if [[ -x "${executable}" ]] && "test_$1" "${executable}"; then
+      echo "${executable}"
       break
     fi
   done
-  IFS=$' \t\n' # Restore IFS to its default value
 }
 
 no_usable_ruby() {

--- a/install.sh
+++ b/install.sh
@@ -302,7 +302,7 @@ find_tool() {
 
   # Search all PATH entries (remove dependency for `which` command)
   local executable entries entry
-  readarray -d ':' -t entries <<< "$PATH"  # as we are using Bash, use readarray
+  IFS=':' read -r -a entries <<< "$PATH"  # `readarray -d ':' -t` seems not applicable on WSL Bash
   for entry in "${entries[@]}"; do
     executable="${entry}/$1"
     if [[ -x "${executable}" ]] && "test_$1" "${executable}"; then

--- a/install.sh
+++ b/install.sh
@@ -264,7 +264,8 @@ file_not_grpowned() {
 
 # Please sync with 'test_ruby()' in 'Library/Homebrew/utils/ruby.sh' from Homebrew/brew repository.
 test_ruby() {
-  if [[ ! -x "$1" ]]; then
+  if [[ ! -x "$1" ]]
+  then
     return 1
   fi
 
@@ -274,7 +275,8 @@ test_ruby() {
 }
 
 test_curl() {
-  if [[ ! -x "$1" ]]; then
+  if [[ ! -x "$1" ]]
+  then
     return 1
   fi
 
@@ -285,7 +287,8 @@ test_curl() {
 }
 
 test_git() {
-  if [[ ! -x "$1" ]]; then
+  if [[ ! -x "$1" ]]
+  then
     return 1
   fi
 
@@ -296,35 +299,38 @@ test_git() {
 
 # Search given executable in all PATH entries (remove dependency for `which` command)
 which_all() {
-  if [[ $# -ne 1 ]]; then
+  if [[ $# -ne 1 ]]
+  then
     return 1
   fi
 
-  local executable entries entry presented=''
+  local executable entries entry retcode=1
   IFS=':' read -r -a entries <<< "${PATH}"  # `readarray -d ':' -t` seems not applicable on WSL Bash
-  for entry in "${entries[@]}"; do
+  for entry in "${entries[@]}"
+  do
     executable="${entry}/$1"
-    if [[ -x "${executable}" ]]; then
+    if [[ -x "${executable}" ]]
+    then
       echo "${executable}"
-      presented='yes'
+      retcode=0  # present
     fi
   done
-  if [[ -n "${presented}" ]]; then
-    return 0
-  else
-    return 1
-  fi
+
+  return "${retcode}"
 }
 
 # Search PATH for the specified program that satisfies Homebrew requirements
 find_tool() {
-  if [[ $# -ne 1 ]]; then
+  if [[ $# -ne 1 ]]
+  then
     return 1
   fi
 
   local executable
-  while read -r executable; do
-    if "test_$1" "${executable}"; then
+  while read -r executable
+  do
+    if "test_$1" "${executable}"
+    then
       echo "${executable}"
       break
     fi


### PR DESCRIPTION
Remove `which` command, search executables under all entries in `PATH`. Closes #574.

BTW, `which` command shows both executable files and aliases.

```console
$ which -a python
/usr/bin/python

$ alias python='python3'

$ which -a python
python: aliased to python3
/usr/bin/python
```

We should never use `which` to find usable commands ([shellcheck SC2230](https://github.com/koalaman/shellcheck/wiki/SC2230)), use `command -v` instead. However, I do not find a `which -a` equivalent for `command -v`. This PR enumerates all entries in `PATH`.