### PR TITLE
Respect `HOMEBREW_PREFIX` if it is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ CI=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/in
 When running the installation unattendedly, you can also set `HOMEBREW_PREFIX` in your shell environment to change the target directory where Homebrew will get installed. Example:
 
 ```bash
-CI=true HOMEBREW_PREFIX=/tmp/linuxbrew /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+HOMEBREW_PREFIX=/tmp/linuxbrew CI=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 ## Uninstall Homebrew

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/insta
 When running the installation unattendedly on Linux, you can also set `HOMEBREW_PREFIX` in your shell environment to change the target directory where Homebrew will get installed. Example:
 
 ```bash
-HOMEBREW_PREFIX=/tmp/linuxbrew CI=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+HOMEBREW_PREFIX=/tmp/linuxbrew CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 Note that installing Homebrew on locations different than the default is not recommended and it is strongly discouraged. While it may work, this functionality is provided without any warranties, and it is not a supported use case for Homebrew itself.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebre
 
 The default Git remote will be used if the corresponding environment variable is unset.
 
-You can set `CI=true` to make the installation unattended. This will disable any interactive prompt, making it suitable for running on CI and on scripts. Note that some CI tools set this environment variable by default, [such as GitHub Actions](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables). Example:
+You can set `CI` environment variable to any non-empty value to make the installation unattended. This will disable any interactive prompt, making it suitable for running on CI and on scripts. Note that some CI tools set this environment variable by default, [such as GitHub Actions](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables). Example:
 
 ```bash
-CI=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 When running the installation unattendedly on Linux, you can also set `HOMEBREW_PREFIX` in your shell environment to change the target directory where Homebrew will get installed. Example:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebre
 
 The default Git remote will be used if the corresponding environment variable is unset.
 
+You can set `CI=true` to make the installation unattended. This will disable any interactive prompt, making it suitable for running on CI and on scripts. Note that some CI tools set this environment variable by default, [such as GitHub Actions](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables). Example:
+
+```bash
+CI=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+When running the installation unattendedly, you can also set `HOMEBREW_PREFIX` in your shell environment to change the target directory where Homebrew will get installed. Example:
+
+```bash
+CI=true HOMEBREW_PREFIX=/tmp/linuxbrew /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
 ## Uninstall Homebrew
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ You can set `CI=true` to make the installation unattended. This will disable any
 CI=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-When running the installation unattendedly, you can also set `HOMEBREW_PREFIX` in your shell environment to change the target directory where Homebrew will get installed. Example:
+When running the installation unattendedly on Linux, you can also set `HOMEBREW_PREFIX` in your shell environment to change the target directory where Homebrew will get installed. Example:
 
 ```bash
 HOMEBREW_PREFIX=/tmp/linuxbrew CI=true /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
+
+Note that installing Homebrew on locations different than the default is not recommended and it is strongly discouraged. While it may work, this functionality is provided without any warranties, and it is not a supported use case for Homebrew itself.
 
 ## Uninstall Homebrew
 

--- a/install.sh
+++ b/install.sh
@@ -458,8 +458,10 @@ if [[ -z "${HOMEBREW_ON_LINUX-}" ]]
 then
   have_sudo_access
 else
-  if [[ -z "${HOMEBREW_PREFIX-}" ]] &&
-     [[ -n "${NONINTERACTIVE-}" ]] ||
+  if [[ -n "${HOMEBREW_PREFIX-}" ]] && [[ -n "${NONINTERACTIVE-}" ]]
+  then
+    HOMEBREW_PREFIX="${HOMEBREW_PREFIX}"
+  elif [[ -n "${NONINTERACTIVE-}" ]] ||
      [[ -w "${HOMEBREW_PREFIX_DEFAULT}" ]] ||
      [[ -w "/home/linuxbrew" ]] ||
      [[ -w "/home" ]]

--- a/install.sh
+++ b/install.sh
@@ -458,7 +458,8 @@ if [[ -z "${HOMEBREW_ON_LINUX-}" ]]
 then
   have_sudo_access
 else
-  if [[ -n "${NONINTERACTIVE-}" ]] ||
+  if [[ -z "${HOMEBREW_PREFIX-}" ]] &&
+     [[ -n "${NONINTERACTIVE-}" ]] ||
      [[ -w "${HOMEBREW_PREFIX_DEFAULT}" ]] ||
      [[ -w "/home/linuxbrew" ]] ||
      [[ -w "/home" ]]


### PR DESCRIPTION
On some environment we simply lack permission for installing on the default location.

This is mainly the case on environments managed by IT where the /home folder gets mounted to a shared NFS drive, using autofs.

This PR also documents the CI environment variable usage, as it was missing.

I noticed that multiple PRs and issues were already opened on this repository for very similar reasons. The reason why they get closed is almost always due to "we don't want to support that", so I made sure to let this explicit in the documentation.

Still, many users need (not because they want, but as for the reason I stated above), and the workaround is to do a bare installation with Git, which is much more complicated.