### PR TITLE
install.sh: fail on insufficient permissions in non-interactive mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,13 @@ jobs:
           /bin/bash uninstall.sh -f >/dev/null
           unset HOMEBREW_{BREW,CORE}{,_DEFAULT}_GIT_REMOTE
 
+      - name: Install and uninstall Homebrew in user home directory on Linux
+        if: runner.os == 'linux'
+        run: |
+          HAVE_SUDO_ACCESS=false /bin/bash -c "$(cat install.sh)"
+          test -x "${HOME}/.linuxbrew/bin/brew"
+          /bin/bash uninstall.sh --path="${HOME}/.linuxbrew"
+
       - run: /bin/bash -c "$(cat install.sh)"
 
       - name: Uninstall and reinstall with sudo NOPASSWD
@@ -117,7 +124,7 @@ jobs:
       - name: Check code styles
         if: runner.os != 'windows'
         run: |
-          brew install shellcheck shfmt
+          brew install shellcheck shfmt diffutils
           brew style *.sh
 
       - run: /bin/bash uninstall.sh -n >/dev/null

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,13 +105,6 @@ jobs:
           /bin/bash uninstall.sh -f >/dev/null
           unset HOMEBREW_{BREW,CORE}{,_DEFAULT}_GIT_REMOTE
 
-      - name: Install and uninstall Homebrew in user home directory on Linux
-        if: runner.os == 'linux'
-        run: |
-          HAVE_SUDO_ACCESS=false /bin/bash -c "$(cat install.sh)"
-          test -x "${HOME}/.linuxbrew/bin/brew"
-          /bin/bash uninstall.sh --path="${HOME}/.linuxbrew"
-
       - run: /bin/bash -c "$(cat install.sh)"
 
       - name: Uninstall and reinstall with sudo NOPASSWD

--- a/install.sh
+++ b/install.sh
@@ -458,12 +458,14 @@ if [[ -z "${HOMEBREW_ON_LINUX-}" ]]
 then
   have_sudo_access
 else
-  if [[ -n "${NONINTERACTIVE-}" ]] ||
-     [[ -w "${HOMEBREW_PREFIX_DEFAULT}" ]] ||
-     [[ -w "/home/linuxbrew" ]] ||
-     [[ -w "/home" ]]
+  if [[ -n "${NONINTERACTIVE-}" ]]
   then
-    HOMEBREW_PREFIX="${HOMEBREW_PREFIX_DEFAULT}"
+    if have_sudo_access
+    then
+      HOMEBREW_PREFIX="${HOMEBREW_PREFIX_DEFAULT}"
+    else
+      HOMEBREW_PREFIX="${HOME}/.linuxbrew"
+    fi
   else
     trap exit SIGINT
     if ! /usr/bin/sudo -n -v &>/dev/null

--- a/install.sh
+++ b/install.sh
@@ -115,6 +115,8 @@ tty_red="$(tty_mkbold 31)"
 tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
+unset HAVE_SUDO_ACCESS # unset this from the environment
+
 have_sudo_access() {
   if [[ ! -x "/usr/bin/sudo" ]]
   then
@@ -458,13 +460,18 @@ if [[ -z "${HOMEBREW_ON_LINUX-}" ]]
 then
   have_sudo_access
 else
-  if [[ -n "${NONINTERACTIVE-}" ]]
+  if [[ -w "${HOMEBREW_PREFIX_DEFAULT}" ]] ||
+     [[ -w "/home/linuxbrew" ]] ||
+     [[ -w "/home" ]]
+  then
+    HOMEBREW_PREFIX="${HOMEBREW_PREFIX_DEFAULT}"
+  elif [[ -n "${NONINTERACTIVE-}" ]]
   then
     if have_sudo_access
     then
       HOMEBREW_PREFIX="${HOMEBREW_PREFIX_DEFAULT}"
     else
-      HOMEBREW_PREFIX="${HOME}/.linuxbrew"
+      abort "Insufficient permissions to install Homebrew to \"${HOMEBREW_PREFIX_DEFAULT}\"."
     fi
   else
     trap exit SIGINT

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -279,8 +279,10 @@ fi
       share/doc/homebrew
       share/man/man1/brew.1
       share/man/man1/brew-cask.1
+      share/man/man1/README.md
       share/zsh/site-functions/_brew
       share/zsh/site-functions/_brew_cask
+      share/fish/vendor_completions.d/brew.fish
       var/homebrew
     )
     for p in "${directories[@]}"


### PR DESCRIPTION
This PR allows users to call the Homebrew installer in their automation scripts without asking password.

The following command will install Homebrew to `~/.linuxbrew` in non-interactive mode rather than `/home/linuxbrew/.linuxbrew`:

```bash
NONINTERACTIVE=true HAVE_SUDO_ACCESS=false bash install.sh
```