### PR TITLE
install.sh: correct detection of arm64 on Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -527,7 +527,7 @@ then
   fi
 else
   # On Linux, support only 64-bit Intel
-  if [[ "${UNAME_MACHINE}" == "arm64" ]]
+  if [[ "${UNAME_MACHINE}" == "aarch64" ]]
   then
     abort "$(
       cat <<EOABORT


### PR DESCRIPTION
'uname -m' returns aarch64, not arm64

ref: https://github.com/Homebrew/install/pull/518
ref: https://github.com/Homebrew/install/commit/0d46eb17cff2649ac15a0b3296c782d75218863f