### PR TITLE
Add force-interactive mode and document variable `NONINTERACTIVE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-More installation information and options: https://docs.brew.sh/Installation.
+More installation information and options: <https://docs.brew.sh/Installation>.
 
 If running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).
 
@@ -19,6 +19,12 @@ export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebre
 ```
 
 The default Git remote will be used if the corresponding environment variable is unset.
+
+If you want to run the Homebrew installer non-iteratively without prompting for passwords (e.g. in automation scripts), you can use:
+
+```bash
+NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
 
 ## Uninstall Homebrew
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebre
 
 The default Git remote will be used if the corresponding environment variable is unset.
 
-If you want to run the Homebrew installer non-iteratively without prompting for passwords (e.g. in automation scripts), you can use:
+If you want to run the Homebrew installer non-interactively without prompting for passwords (e.g. in automation scripts), you can use:
 
 ```bash
 NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
Changes:

1. Add variable `INTERACTIVE` for force-interactive mode. ~~The variable can be changed with a warning when both `NONINTERACTIVE` and `INTERACTIVE` are set.~~
2. Show messages when `INTERACTIVE` and/or `NONINTERACTIVE` are set. Use `ohai` when the variable is set by the user and `warn` when the variable is set by the installer.
3. Add documentation for variable `NONINTERACTIVE`. (Variable `INTERACTIVE` is not added since it is a rare use-case).