### PR TITLE
always remove command line tools placeholder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -860,9 +860,9 @@ then
   then
     ohai "Installing ${clt_label}"
     execute_sudo "/usr/sbin/softwareupdate" "-i" "${clt_label}"
-    execute_sudo "/bin/rm" "-f" "${clt_placeholder}"
     execute_sudo "/usr/bin/xcode-select" "--switch" "/Library/Developer/CommandLineTools"
   fi
+  execute_sudo "/bin/rm" "-f" "${clt_placeholder}"
 fi
 
 # Headless install may have failed, so fallback to original 'xcode-select' method


### PR DESCRIPTION
I was looking for inspiration on how homebrew does a silent install of Command Line Tools,
and noticed that removing the placeholder is wrapped in the conditional.
In practice, I don't see how command line tools are not installed, and softwareupdate can come up empty handed, but who knows. I honestly don't know if/what consequences there are if the placeholder is left behind.