### PR TITLE
workflows/tests: remove non-default workflows tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,21 +91,6 @@ jobs:
 
       - run: /bin/bash uninstall.sh -f >/dev/null
 
-      - name: Install Homebrew with non-default remotes
-        # Use the default remotes but with Git Protocol
-        run: |
-          HOMEBREW_BREW_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/brew"
-          HOMEBREW_CORE_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/homebrew-core"
-          export HOMEBREW_BREW_GIT_REMOTE="${HOMEBREW_BREW_DEFAULT_GIT_REMOTE/#https/git}"
-          export HOMEBREW_CORE_GIT_REMOTE="${HOMEBREW_CORE_DEFAULT_GIT_REMOTE/#https/git}"
-          /bin/bash -c "$(cat install.sh)"
-
-      - run: brew config
-
-      - run: |
-          /bin/bash uninstall.sh -f >/dev/null
-          unset HOMEBREW_{BREW,CORE}{,_DEFAULT}_GIT_REMOTE
-
       - run: /bin/bash -c "$(cat install.sh)"
 
       - name: Uninstall and reinstall with sudo NOPASSWD


### PR DESCRIPTION
Now that `git://` is disabled on GitHub: this test no longer works.