### PR TITLE
Respect `$HOMEBREW_INSTALL_FROM_API` in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -759,6 +759,13 @@ then
   additional_shellenv_commands+=("export HOMEBREW_CORE_GIT_REMOTE=\"${HOMEBREW_CORE_GIT_REMOTE}\"")
 fi
 
+if [[ -n "${HOMEBREW_INSTALL_FROM_API-}" ]]
+then
+  ohai "HOMEBREW_INSTALL_FROM_API is set."
+  echo "Homebrew/homebrew-core will not be tapped during this ${tty_bold}install${tty_reset} run."
+  additional_shellenv_commands+=("export HOMEBREW_INSTALL_FROM_API=\"${HOMEBREW_INSTALL_FROM_API}\"")
+fi
+
 if [[ -z "${NONINTERACTIVE-}" ]]
 then
   ring_bell
@@ -916,7 +923,15 @@ ohai "Downloading and installing Homebrew..."
     fi
   fi
 
-  if [[ ! -d "${HOMEBREW_CORE}" ]]
+  if [[ -n "${HOMEBREW_INSTALL_FROM_API-}" ]]
+  then
+    ohai 'Skip tapping homebrew/core because `$HOMEBREW_INSTALL_FROM_API` is set.'
+    # Unset HOMEBREW_DEVELOPER since it is no longer needed and causes warnings during brew update below
+    if [[ -n "${HOMEBREW_ON_LINUX-}" && (-n "${HOMEBREW_CURL_PATH-}" || -n "${HOMEBREW_GIT_PATH-}") ]]
+    then
+      export -n HOMEBREW_DEVELOPER
+    fi
+  elif [[ ! -d "${HOMEBREW_CORE}" ]]
   then
     ohai "Tapping homebrew/core"
     (


### PR DESCRIPTION
The `$HOMEBREW_INSTALL_FROM_API` environment, which lets Homebrew use the homebrew/core and homebrew/cask without local git checkout, is [official supported since 3.3.0](https://brew.sh/2021/10/25/homebrew-3.3.0/).

This pull request makes the install script respect this environment variable, by skip cloning homebrew/core entirely during installation if `$HOMEBREW_INSTALL_FROM_API` is set.

This also addresses #523 with a different approach, by allowing a minimal installation possible with the official installation script instead of a hand-rolled one.