### PR TITLE
install: sharball release support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,16 @@ jobs:
 
       - run: /bin/bash uninstall.sh -f >/dev/null
 
+      - name: Create sharball installer
+        run: /bin/bash sharball-release.sh
+
+      - name: Install Homebrew with sharball installer
+        run: /bin/bash Homebrew-latest.sh
+
+      - run: brew config
+
+      - run: /bin/bash uninstall.sh -f >/dev/null
+
       - run: /bin/bash -c "$(cat install.sh)"
 
       - name: Uninstall and reinstall with sudo NOPASSWD
@@ -104,7 +114,7 @@ jobs:
         if: runner.os != 'windows'
         run: |
           brew install shellcheck shfmt diffutils
-          brew style *.sh
+          brew style install.sh uninstall.sh sharball-release.sh
 
       - run: /bin/bash uninstall.sh -n >/dev/null
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Sharball installers
+Homebrew-*.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ If you want to run the Homebrew installer non-interactively without prompting fo
 NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
+## Create Offline Installer
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/sharball-release.sh)"
+```
+
+This script will create a sharball installer `Homebrew-<tag>.sh` with the latest release of Homebrew. Then you can run:
+
+```bash
+/bin/bash Homebrew-<tag>.sh
+```
+
+to install Homebrew.
+
 ## Uninstall Homebrew
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# @@SHEBANG@@
+
 # We don't need return codes for "$(command)", only stdout is needed.
 # Allow `[[ -n "$(command)" ]]`, `func "$(command)"`, pipes, etc.
 # shellcheck disable=SC2312
@@ -421,6 +423,17 @@ if [[ -x /usr/bin/sudo ]] && ! /usr/bin/sudo -n -v 2>/dev/null
 then
   trap '/usr/bin/sudo -k' EXIT
 fi
+
+# Variable for sharball release
+# shellcheck disable=SC2034
+THIS_DIR="$(
+  cd "$(dirname "$0")" || exit 1
+  pwd -P
+)"
+
+# Variable for sharball release
+# shellcheck disable=SC2034
+THIS_FILE="${THIS_DIR}/$(basename "$0")"
 
 # Things can fail later if `pwd` doesn't exist.
 # Also sudo prints a warning message for no good reason
@@ -893,9 +906,11 @@ EOABORT
   )"
 fi
 
-ohai "Downloading and installing Homebrew..."
 (
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
+
+  # @@INSTALL-START@@
+  ohai "Downloading and installing Homebrew..."
 
   # we do it in four steps to avoid merge errors when reinstalling
   execute "git" "init" "-q"
@@ -911,6 +926,7 @@ ohai "Downloading and installing Homebrew..."
   execute "git" "fetch" "--force" "--tags" "origin"
 
   execute "git" "reset" "--hard" "origin/master"
+  # @@INSTALL-END@@
 
   if [[ "${HOMEBREW_REPOSITORY}" != "${HOMEBREW_PREFIX}" ]]
   then
@@ -1059,3 +1075,6 @@ cat <<EOS
     ${tty_underline}https://docs.brew.sh${tty_reset}
 
 EOS
+
+exit
+# @@END-HEADER@@

--- a/sharball-release.sh
+++ b/sharball-release.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# We don't need return codes for "$(command)", only stdout is needed.
+# Allow `[[ -n "$(command)" ]]`, `func "$(command)"`, pipes, etc.
+# shellcheck disable=SC2312
+
+set -u
+
+abort() {
+  printf "%s\n" "$@"
+  exit 1
+}
+
+# Fail fast with a concise message when not using bash
+# Single brackets are needed here for POSIX compatibility
+# shellcheck disable=SC2292
+if [ -z "${BASH_VERSION:-}" ]
+then
+  abort "Bash is required to interpret this script."
+fi
+
+# string formatters
+if [[ -t 1 ]]
+then
+  tty_escape() { printf "\033[%sm" "$1"; }
+else
+  tty_escape() { :; }
+fi
+tty_mkbold() { tty_escape "1;$1"; }
+tty_blue="$(tty_mkbold 34)"
+tty_bold="$(tty_mkbold 39)"
+tty_reset="$(tty_escape 0)"
+
+shell_join() {
+  local arg
+  printf "%s" "$1"
+  shift
+  for arg in "$@"
+  do
+    printf " "
+    printf "%s" "${arg// /\ }"
+  done
+}
+
+ohai() {
+  printf "${tty_blue}==>${tty_bold} %s${tty_reset}\n" "$(shell_join "$@")"
+}
+
+line_range_of() {
+  # Usage: line_range_of file start end
+  head -n +"$3" "$1" | tail -n +"$2"
+}
+
+curl() {
+  command curl -fSL --retry "${HOMEBREW_CURL_RETRIES:-3}" "$@"
+}
+
+wait_for() {
+  local MESSAGE="$2" TIME="$1" t s="s"
+  echo "${MESSAGE}" >&2
+  echo -ne "\033[?25l" >&2
+  for ((t = TIME; t > 0; --t))
+  do
+    ((t > 1)) || s=""
+    echo -ne "Wait for ${t} second${s}.\033[K\r" >&2
+    sleep 1
+  done
+  echo -ne "\033[K\033[?25h" >&2
+}
+
+get_latest_version() {
+  # Usage: get_latest_version repo timeout
+  local REPO="$1" VERSION=""
+  local TIMEOUT="${2:-300}"
+  local TIME=0 INTERVAL=1 t
+
+  while true
+  do
+    ((TIME > 0)) && echo "Retrying..." >&2
+
+    VERSION="$(
+      curl --silent --connect-timeout 10 "https://api.github.com/repos/${REPO}/releases/latest" |
+        grep '"tag_name":' |
+        sed -E 's/^.*: *"([^"]+)",?$/\1/'
+    )"
+    if [[ -n "${VERSION}" ]] || ((TIME >= TIMEOUT))
+    then
+      break
+    fi
+
+    wait_for "${INTERVAL}" "Failed to find latest release of ${REPO}."
+    TIME="$((TIME + INTERVAL))"
+    INTERVAL="$((INTERVAL * 2))"
+  done
+
+  echo "${VERSION}"
+  [[ -n "${VERSION}" ]]
+}
+
+# Create temporary directory
+TMP_DIR="$(mktemp -d -t brew-install.XXXXXX)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+REPO="Homebrew/brew"
+ohai "Querying for latest release of ${REPO}..."
+TAG="$(get_latest_version "${REPO}")"
+
+if [[ -z "${TAG}" ]]
+then
+  abort "Failed to find latest release of ${REPO}. Please check your Internet connection and try again."
+fi
+
+echo "Found release version ${TAG} of ${REPO}."
+
+TARBALL="${TMP_DIR}/Homebrew-${TAG}.tar.gz"
+(
+  cd "${TMP_DIR}" || exit 1
+  ohai "Downloading the latest release of ${REPO}@${TAG}..."
+  curl --progress-bar --connect-timeout 30 "https://api.github.com/repos/${REPO}/tarball/${TAG}" >"${TARBALL}"
+) || exit 1
+SHA256="$(shasum -a 256 "${TARBALL}" | cut -d' ' -f1)"
+
+OUTPUT_FILE="Homebrew-${TAG}.sh"
+
+cat <<EOF
+NAME:   Homebrew/brew
+TAG:    ${TAG}
+SHA256: ${SHA256}
+EOF
+
+THIS_DIR="$(
+  cd "$(dirname "$0")" || exit 1
+  pwd -P
+)" || exit 1
+if [[ -f "${THIS_DIR}/install.sh" ]]
+then
+  TEMPLATE="${THIS_DIR}/install.sh"
+else
+  TEMPLATE="${TMP_DIR}/install.sh"
+  curl --silent --connect-timeout 30 https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh >"${TEMPLATE}"
+fi
+
+shebang_lineno="$(grep -anm 1 -E '\s*# @@SHEBANG@@$' "${TEMPLATE}" | cut -d':' -f1)"
+install_start_lineno="$(grep -anm 1 -E '\s*# @@INSTALL-START@@$' "${TEMPLATE}" | cut -d':' -f1)"
+install_end_lineno="$(grep -anm 1 -E '\s*# @@INSTALL-END@@$' "${TEMPLATE}" | cut -d':' -f1)"
+end_lineno="$(grep -anm 1 -E '\s*# @@END-HEADER@@$' "${TEMPLATE}" | cut -d':' -f1)"
+
+shebang="$(
+  cat <<EOF
+#!/bin/bash
+
+# NAME:   Homebrew/brew
+# TAG:    ${TAG}
+# SHA256: ${SHA256}
+EOF
+)"
+
+extractor="$(
+  cat <<EOF
+  # @@EXTRACTOR-START@@
+  ohai "Installing Homebrew..."
+
+  # Verify the SHA256 checksum of the tarball appended to this script
+  HEADER_LINES="\$(grep -anm 1 -E '\\s*# @@END-HEADER@@\$' "\${THIS_FILE}" | cut -d':' -f1)"
+  SHA256="\$(tail -n +"\$((HEADER_LINES + 1))" "\${THIS_FILE}" | shasum -a 256 - | cut -d' ' -f1)"
+  [[ "\${SHA256}" == "${SHA256}" ]] || abort "\$(
+    cat <<EOABORT
+  WARNING: SHA256 checksum mismatch of tar archive
+  expected: ${SHA256}
+       got: \${SHA256}
+EOABORT
+  )"
+
+  ohai "Extacting tarball archive to \${HOMEBREW_REPOSITORY}..."
+  tail -n +"\$((HEADER_LINES + 1))" "\${THIS_FILE}" |
+    tar -xz --strip-components=1 -C "\${HOMEBREW_REPOSITORY}"
+  # @@EXTRACTOR-END@@
+EOF
+)"
+
+{
+  echo "${shebang}"
+  line_range_of "${TEMPLATE}" "$((shebang_lineno + 1))" "$((install_start_lineno - 1))"
+  echo "${extractor}"
+  line_range_of "${TEMPLATE}" "$((install_end_lineno + 1))" "${end_lineno}"
+  cat "${TARBALL}"
+} >"${OUTPUT_FILE}" # Homebrew-<tag>.sh
+
+chmod +x "${OUTPUT_FILE}"
+ln -f "${OUTPUT_FILE}" Homebrew-latest.sh # make hardlink with a constant name (Homebrew-latest.sh)
+
+ohai "Successfully created Homebrew/brew ${TAG} installer to ${THIS_DIR}/${OUTPUT_FILE}."


### PR DESCRIPTION
Add a new script to create a standalone sharball installer.

In the installer creator:

1. get the latest tag of Homebrew/brew from GItHub API
2. download tarball of Homebrew/brew
3. embed the tarball into `install.sh`

See also #634.