### PR TITLE
Fix install.sh failure when the umask is not 0022

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
   pull_request:
-  workflow_dispatch:
 jobs:
   tests:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 jobs:
   tests:
     strategy:

--- a/install.sh
+++ b/install.sh
@@ -129,6 +129,7 @@ then
   CHGRP=("/usr/bin/chgrp")
   GROUP="admin"
   TOUCH=("/usr/bin/touch")
+  INSTALL=("/usr/bin/install" -d -o "root" -g "wheel" -m "0750")
 else
   UNAME_MACHINE="$(uname -m)"
 
@@ -143,6 +144,7 @@ else
   CHGRP=("/bin/chgrp")
   GROUP="$(id -gn)"
   TOUCH=("/bin/touch")
+  INSTALL=("/usr/bin/install" -d -o "${USER}" -g "${GROUP}" -m "0750")
 fi
 CHMOD=("/bin/chmod")
 MKDIR=("/bin/mkdir" "-p")
@@ -794,13 +796,7 @@ then
     execute_sudo "${CHGRP[@]}" "${GROUP}" "${chgrps[@]}"
   fi
 else
-  execute_sudo "${MKDIR[@]}" "${HOMEBREW_PREFIX}"
-  if [[ -z "${HOMEBREW_ON_LINUX-}" ]]
-  then
-    execute_sudo "${CHOWN[@]}" "root:wheel" "${HOMEBREW_PREFIX}"
-  else
-    execute_sudo "${CHOWN[@]}" "${USER}:${GROUP}" "${HOMEBREW_PREFIX}"
-  fi
+  execute_sudo "${INSTALL[@]}" "${HOMEBREW_PREFIX}"
 fi
 
 if [[ "${#mkdirs[@]}" -gt 0 ]]

--- a/install.sh
+++ b/install.sh
@@ -129,7 +129,7 @@ then
   CHGRP=("/usr/bin/chgrp")
   GROUP="admin"
   TOUCH=("/usr/bin/touch")
-  INSTALL=("/usr/bin/install" -d -o "root" -g "wheel" -m "0750")
+  INSTALL=("/usr/bin/install" -d -o "root" -g "wheel" -m "0755")
 else
   UNAME_MACHINE="$(uname -m)"
 
@@ -144,7 +144,7 @@ else
   CHGRP=("/bin/chgrp")
   GROUP="$(id -gn)"
   TOUCH=("/bin/touch")
-  INSTALL=("/usr/bin/install" -d -o "${USER}" -g "${GROUP}" -m "0750")
+  INSTALL=("/usr/bin/install" -d -o "${USER}" -g "${GROUP}" -m "0755")
 fi
 CHMOD=("/bin/chmod")
 MKDIR=("/bin/mkdir" "-p")


### PR DESCRIPTION
HOMEBREW_PREFIX was created using mkdir -p which respects the user
umask, even when using sudo causing the wrong permissions to be set
when installing into /home/linuxbrew.

This fixes the issue by replacing mkdir with install creating the
missing parents with the specified permissions. To make it work on
linux and macos remember to only use single letter flags.

Fixes #637