### PR TITLE
Check for `brew` in `PATH` when displaying `PATH` instructions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1003,7 +1003,10 @@ case "${SHELL}" in
     shell_profile="${HOME}/.profile"
     ;;
 esac
-if [[ "${UNAME_MACHINE}" == "arm64" ]] || [[ -n "${HOMEBREW_ON_LINUX-}" ]]
+
+# `which` is a shell function defined above.
+# shellcheck disable=SC2230
+if [[ "$(which brew)" != "${HOMEBREW_PREFIX}/bin/brew" ]]
 then
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:


### PR DESCRIPTION
Currently, we display instructions about adding `brew` to `PATH` when we
are running on ARM64 or on Linux. This isn't a terrible heuristic, but
we can do better by checking whether `brew` is in `PATH` instead.

Fixes https://twitter.com/TayIorRobinson/status/1524683234956750852.