### PR TITLE
unset `GIT_DIR` and `GIT_WORK_TREE`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,7 @@ REQUIRED_GIT_VERSION=2.7.0   # HOMEBREW_MINIMUM_GIT_VERSION in brew.sh in Homebr
 export HOMEBREW_NO_ANALYTICS_THIS_RUN=1
 export HOMEBREW_NO_ANALYTICS_MESSAGE_OUTPUT=1
 
-unset HAVE_SUDO_ACCESS # unset this from the environment
+unset GIT_DIR GIT_WORK_TREE HAVE_SUDO_ACCESS # unset these from the environment
 
 have_sudo_access() {
   if [[ ! -x "/usr/bin/sudo" ]]


### PR DESCRIPTION
These environment variables allow overriding the `.git` and working directories for `git` commands. Before this change, a user with these set would cause our installer to clone the `Homebrew/brew` repo to `$GIT_WORK_TREE`

See https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables

For a reproduction:

```sh
cd "$(mktemp -d)"
export GIT_DIR="$(pwd)/.git"
export GIT_WORK_TREE="$(pwd)"
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
ls -la
```

Note, I encountered this issue as a [`yadm`](https://github.com/TheLocehiliosan/yadm) user, which sets these to manage a dotfiles repo.