### PR TITLE
uninstall.sh: add variable `NONINTERACTIVE` for non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,10 @@ NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Ho
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 ```
 
+If you want to run the Homebrew uninstaller non-interactively, you can use:
+
+```bash
+NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+```
+
 Download the uninstall script and run `/bin/bash uninstall.sh --help` to view more uninstall options.

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -208,7 +208,7 @@ Usage: [NONINTERACTIVE=1] $0 [options]
     -q, --quiet      Suppress all output.
     -n, --dry-run    Simulate uninstall but don't remove anything.
     -h, --help       Display this message.
-    NONINTERACTIVE   Imply `--force` if NONINTERACTIVE is non-empty.
+	NONINTERACTIVE   Imply --force if NONINTERACTIVE is non-empty.
 EOS
   exit "${1:-0}"
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -53,7 +53,6 @@ opt_force=""
 opt_quiet=""
 opt_dry_run=""
 opt_skip_cache_and_logs=""
-NONINTERACTIVE="${NONINTERACTIVE:-0}"
 
 # global status to indicate whether there is anything wrong.
 failed=false
@@ -209,7 +208,7 @@ Usage: [NONINTERACTIVE=1] $0 [options]
     -q, --quiet      Suppress all output.
     -n, --dry-run    Simulate uninstall but don't remove anything.
     -h, --help       Display this message.
-    NONINTERACTIVE   Uninstall without prompting if NONINTERACTIVE is set to 1.
+    NONINTERACTIVE   Imply `--force` if NONINTERACTIVE is non-empty.
 EOS
   exit "${1:-0}"
 }
@@ -344,9 +343,15 @@ then
   pretty_print_pathnames "${homebrew_files[@]}"
 fi
 
-[[ "${NONINTERACTIVE}" -ne 1 ]] || ohai "Running in non-interactive mode because `$NONINTERACTIVE` is set."
+# Always use single-quoted strings with `exp` expressions
+# shellcheck disable=SC2016
+if [[ -n "${NONINTERACTIVE-}" ]]
+then
+  ohai 'Running in non-interactive mode because `$NONINTERACTIVE` is set.'
+  opt_force=1
+fi
 
-if [[ -t 0 && -z "${opt_force}" && -z "${opt_dry_run}" && "${NONINTERACTIVE}" -ne 1 ]]
+if [[ -t 0 && -z "${opt_force}" && -z "${opt_dry_run}" ]]
 then
   read -rp "Are you sure you want to uninstall Homebrew? This will remove your installed packages! [y/N] "
   [[ "${REPLY}" == [yY]* ]] || abort

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -344,7 +344,7 @@ then
   pretty_print_pathnames "${homebrew_files[@]}"
 fi
 
-[[ "${NONINTERACTIVE}" -ne 1 ]] || ohai 'Running in non-interactive mode because `$NONINTERACTIVE` is set.'
+[[ "${NONINTERACTIVE}" -ne 1 ]] || ohai "Running in non-interactive mode because `$NONINTERACTIVE` is set."
 
 if [[ -t 0 && -z "${opt_force}" && -z "${opt_dry_run}" && "${NONINTERACTIVE}" -ne 1 ]]
 then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -208,7 +208,7 @@ Usage: [NONINTERACTIVE=1] $0 [options]
     -q, --quiet      Suppress all output.
     -n, --dry-run    Simulate uninstall but don't remove anything.
     -h, --help       Display this message.
-	NONINTERACTIVE   Imply --force if NONINTERACTIVE is non-empty.
+    NONINTERACTIVE   Imply --force if NONINTERACTIVE is non-empty.
 EOS
   exit "${1:-0}"
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -53,6 +53,7 @@ opt_force=""
 opt_quiet=""
 opt_dry_run=""
 opt_skip_cache_and_logs=""
+NONINTERACTIVE="${NONINTERACTIVE:-0}"
 
 # global status to indicate whether there is anything wrong.
 failed=false
@@ -200,7 +201,7 @@ homebrew_prefix_candidates=()
 usage() {
   cat <<EOS
 Homebrew Uninstaller
-Usage: $0 [options]
+Usage: [NONINTERACTIVE=1] $0 [options]
     -p, --path=PATH  Sets Homebrew prefix. Defaults to ${homebrew_prefix_default}.
         --skip-cache-and-logs
                      Skips removal of HOMEBREW_CACHE and HOMEBREW_LOGS.
@@ -208,6 +209,7 @@ Usage: $0 [options]
     -q, --quiet      Suppress all output.
     -n, --dry-run    Simulate uninstall but don't remove anything.
     -h, --help       Display this message.
+    NONINTERACTIVE   Uninstall without prompting if NONINTERACTIVE is set to 1.
 EOS
   exit "${1:-0}"
 }
@@ -342,7 +344,9 @@ then
   pretty_print_pathnames "${homebrew_files[@]}"
 fi
 
-if [[ -t 0 && -z "${opt_force}" && -z "${opt_dry_run}" ]]
+[[ "${NONINTERACTIVE}" -ne 1 ]] || ohai 'Running in non-interactive mode because `$NONINTERACTIVE` is set.'
+
+if [[ -t 0 && -z "${opt_force}" && -z "${opt_dry_run}" && "${NONINTERACTIVE}" -ne 1 ]]
 then
   read -rp "Are you sure you want to uninstall Homebrew? This will remove your installed packages! [y/N] "
   [[ "${REPLY}" == [yY]* ]] || abort


### PR DESCRIPTION
Resolve #654 

Changes :
1. Add variable `NONINTERACTIVE` for non interactive mode. If this variable set to "1", this script will be executed as non interactive mode. In other case ( ex) NONINTERACTIVE is not set or not set to 1 ), it will be executed as interactive mode. 