### PR TITLE
Update uninstall.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -234,9 +234,9 @@ done
 # Attempt to locate Homebrew unless `--path` is passed
 if [[ "${#homebrew_prefix_candidates[@]}" -eq 0 ]]
 then
-  prefix="$(brew --prefix)"
+  prefix="$($homebrew_prefix_default/bin/brew --prefix)"
   [[ -n "${prefix}" ]] && homebrew_prefix_candidates+=("${prefix}")
-  prefix="$(command -v brew)" || prefix=""
+  prefix="$(command -v $homebrew_prefix_default/bin/brew)" || prefix=""
   [[ -n "${prefix}" ]] && homebrew_prefix_candidates+=("$(dirname "$(dirname "$(strip_s "${prefix}")")")")
   homebrew_prefix_candidates+=("${homebrew_prefix_default}") # Homebrew default path
   homebrew_prefix_candidates+=("${HOME}/.linuxbrew")         # Linuxbrew default path

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -234,9 +234,9 @@ done
 # Attempt to locate Homebrew unless `--path` is passed
 if [[ "${#homebrew_prefix_candidates[@]}" -eq 0 ]]
 then
-  prefix="$($homebrew_prefix_default/bin/brew --prefix)"
+  prefix="$("${homebrew_prefix_default}"/bin/brew --prefix)"
   [[ -n "${prefix}" ]] && homebrew_prefix_candidates+=("${prefix}")
-  prefix="$(command -v $homebrew_prefix_default/bin/brew)" || prefix=""
+  prefix="$(command -v "${homebrew_prefix_default}"/bin/brew)" || prefix=""
   [[ -n "${prefix}" ]] && homebrew_prefix_candidates+=("$(dirname "$(dirname "$(strip_s "${prefix}")")")")
   homebrew_prefix_candidates+=("${homebrew_prefix_default}") # Homebrew default path
   homebrew_prefix_candidates+=("${HOME}/.linuxbrew")         # Linuxbrew default path


### PR DESCRIPTION
## Changes

Use the correct `brew` command in different arch ( according to `$homebrew_prefix_default` )

## Current issue

I installed both *x86_64* and *arm64* `brew` on my m1 mac, however, when I tried to uninstall the *x86_64* one with `uninstall.sh`, warning would remind me that the *arm64* one will be removed:

```sh
❯ uname -m
x86_64

❯ arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
Warning: This script will remove:
/Users/xxx/Library/Caches/Homebrew/
/Users/xxx/Library/Logs/Homebrew/
/opt/homebrew/.dockerignore
/opt/homebrew/.editorconfig
/opt/homebrew/.git/
/opt/homebrew/.github/
/opt/homebrew/.gitignore
/opt/homebrew/.shellcheckrc
/opt/homebrew/.sublime/
/opt/homebrew/.vale.ini
/opt/homebrew/.vscode/
/opt/homebrew/CHANGELOG.md
/opt/homebrew/CONTRIBUTING.md
/opt/homebrew/Caskroom/
/opt/homebrew/Cellar/
/opt/homebrew/Dockerfile
/opt/homebrew/LICENSE.txt
/opt/homebrew/Library//
/opt/homebrew/README.md
/opt/homebrew/bin/brew
/opt/homebrew/completions/
/opt/homebrew/docs/
/opt/homebrew/manpages/
Are you sure you want to uninstall Homebrew? This will remove your installed packages! [y/N]
```

## Using my PR

After using the correct `brew`:

```sh
❯ sudo arch -x86_64 /bin/bash uninstall.sh
Warning: This script will remove:
/Users/xxx/Library/Caches/Homebrew/
/Users/xxx/Library/Logs/Homebrew/
/usr/local/Caskroom/
/usr/local/Cellar/
/usr/local/bin/brew -> /usr/local/bin/brew
Are you sure you want to uninstall Homebrew? This will remove your installed packages! [y/N]
```