### PR TITLE
Added /usr/local to search path for M1 system 

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -244,8 +244,8 @@ then
   [[ -n "${prefix}" ]] && homebrew_prefix_candidates+=("${prefix}")
   prefix="$(command -v "${homebrew_prefix_default}"/bin/brew)" || prefix=""
   [[ -n "${prefix}" ]] && homebrew_prefix_candidates+=("$(dirname "$(dirname "$(strip_s "${prefix}")")")")
-  homebrew_prefix_candidates+=("${homebrew_prefix_default}") # Homebrew default path
-  homebrew_prefix_candidates+=("${HOME}/.linuxbrew")         # Linuxbrew default path
+  homebrew_prefix_candidates+=("${homebrew_prefix_default}")                   # Homebrew default path
+  homebrew_prefix_candidates+=("${HOME}/.linuxbrew")                           # Linuxbrew default path
   [[ "$(uname -m)" == "arm64" ]] && homebrew_prefix_candidates+=("/usr/local") # If migrated from Intel to ARM old path will remain
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -246,6 +246,7 @@ then
   [[ -n "${prefix}" ]] && homebrew_prefix_candidates+=("$(dirname "$(dirname "$(strip_s "${prefix}")")")")
   homebrew_prefix_candidates+=("${homebrew_prefix_default}") # Homebrew default path
   homebrew_prefix_candidates+=("${HOME}/.linuxbrew")         # Linuxbrew default path
+  [[ "$(uname -m)" == "arm64" ]] && homebrew_prefix_candidates+=("/usr/local") # If migrated from Intel to ARM old path will remain
 fi
 
 HOMEBREW_PREFIX="$(


### PR DESCRIPTION
if upgraded to M1 from Intel homebrew will still be installed in /usr/local and will be looked in /opt so now uninstall will look at /usr/local too if explicit path is not set