### PR TITLE
install: add newline to post install command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1018,7 +1018,7 @@ if [[ "$(which brew)" != "${HOMEBREW_PREFIX}/bin/brew" ]]
 then
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_profile}
+    echo '\neval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 fi


### PR DESCRIPTION
When I installed homebrew, the command to update `~/.zprofile` outputted onto the same line as the previous command written to that file

![image](https://user-images.githubusercontent.com/1562283/191366599-0c209cce-e164-4845-8bc2-253d1f836990.png)
