### PR TITLE
Add a temporary patch for missing install-info on some systems

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -25,6 +25,16 @@ then
   abort 'Bash must not run in POSIX mode. Please unset POSIXLY_CORRECT and try again.'
 fi
 
+if ! command -v install-info &> /dev/null
+then
+  cat <<EOS
+install-info is needed as part of the uninstall process.
+Please install the texinfo package (via Homebrew or your system package manager).
+You also need to ensure it is exported as part of your PATH.
+EOS
+  exit 1
+fi
+
 shopt -s extglob
 
 strip_s() {
@@ -385,7 +395,7 @@ then
     echo "Would delete:"
   else
     args+=(-exec /bin/bash -c)
-    args+=("/usr/bin/install-info --delete --quiet {} \"\$(dirname {})/dir\"")
+    args+=("$(command -v install-info) --delete --quiet {} \"\$(dirname {})/dir\"")
     args+=(';')
   fi
   system /usr/bin/find "${args[@]}"


### PR DESCRIPTION
Closes: https://github.com/Homebrew/install/issues/688

<img width="631" alt="CleanShot 2022-09-28 at 00 04 34@2x" src="https://user-images.githubusercontent.com/14816406/192513441-997b282e-f4be-49f0-9312-cc5c0e97640f.png">

I don't love this PR but it seems to do the trick as a workaround for the lack of `install-info` on some systems.

Since the uninstall script implicitly depends on `install-info` already, I opted to just make it an explicit requirement instead of anything fancy.

I've also changed the hardcoding of `/usr/bin/install-info` to instead rely on the user's `PATH` given that `texinfo` (which provides `install-info`) is keg-only and not reachable via the default Homebrew pathing.

Anyway, I've nuked my Brew installation successfully with this script so it should be good to go 🙂 