### PR TITLE
uninstall: remove use of `install-info`

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -373,22 +373,6 @@ do
 done
 if [[ "${#paths[@]}" -gt 0 ]]
 then
-  if [[ "${ostype}" == macos ]]
-  then
-    args=(-E "${paths[@]}" -regex '.*/info/([^.][^/]*\.info|dir)')
-  else
-    args=("${paths[@]}" -regextype posix-extended -regex '.*/info/([^.][^/]*\.info|dir)')
-  fi
-  if [[ -n "${opt_dry_run}" ]]
-  then
-    args+=(-print)
-    echo "Would delete:"
-  else
-    args+=(-exec /bin/bash -c)
-    args+=("/usr/bin/install-info --delete --quiet {} \"\$(dirname {})/dir\"")
-    args+=(';')
-  fi
-  system /usr/bin/find "${args[@]}"
   args=("${paths[@]}" -type l -lname '*/Cellar/*')
   if [[ -n "${opt_dry_run}" ]]
   then


### PR DESCRIPTION
These can be cleaned up by hand and `install-info` doesn't ship with some versions of Linux and macOS Ventura.

Fixes #688
Closes #699