### PR TITLE
install.sh: Fix broken docs link for ARM Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -559,8 +559,7 @@ else
     abort "$(
       cat <<EOABORT
 Homebrew on Linux is not supported on ARM processors.
-You can try an alternate installation method instead:
-  ${tty_underline}https://docs.brew.sh/Homebrew-on-Linux#arm${tty_reset}
+  ${tty_underline}https://docs.brew.sh/Homebrew-on-Linux#arm-unsupported${tty_reset}
 EOABORT
     )"
   elif [[ "${UNAME_MACHINE}" != "x86_64" ]]


### PR DESCRIPTION
- I found it a little misleading that we said "alternate installation methods" but the "ARM unsupported" docs page doesn't refer the user to those.

- I am tempted to improve this situation with an "if you know what you are doing and won't ask for help, you can install Homebrew on ARM Linux", and gate it also with `HOMEBREW_DEVELOPER` or something? Since in my experiments with Homebrew on ARM Linux I had to comment out line 555 ("`else` variously abort") to get past that message. Yet the docs say that while it may be _unsupported_ (fine), it is _possible_, which the installer currently doesn't respect.