### PR TITLE
install.sh: always recommend `brew shellenv`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1001,17 +1001,11 @@ case "${SHELL}" in
     ;;
 esac
 
-# `which` is a shell function defined above.
-# shellcheck disable=SC2230
-if [[ "$(which brew)" != "${HOMEBREW_PREFIX}/bin/brew" ]]
-then
-  cat <<EOS
-- Run these three commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    echo '# Set PATH, MANPATH, etc., for Homebrew.' >> ${shell_profile}
-    echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_profile}
+cat <<EOS
+- Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
+    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
-fi
 if [[ -n "${non_default_repos}" ]]
 then
   plural=""


### PR DESCRIPTION
Currently, Intel macOS installs almost certainly *don't* recommend `brew shellenv`, because `/usr/local` is in `PATH` by default.

Since `brew shellenv` is designed to be idempotent, and it sets environment variables like `INFOPATH` which can affect Homebrew operations in unexpected ways (e.g. https://github.com/Homebrew/brew/issues/14356#issuecomment-1380557154), I think `brew shellenv` should *always* be recommended.

Closes https://github.com/Homebrew/brew/issues/14362.

Also use `printf` to properly fix the "no trailing newline in profile" case.