### PR TITLE
Use HOMEBREW_INSTALL_FROM_API by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ More installation information and options: <https://docs.brew.sh/Installation>.
 
 If running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).
 
+You can set `HOMEBREW_NO_INSTALL_FROM_API` to tap Homebrew/homebrew-core; by default, it will not be tapped as it is no longer necessary.
+
 You can set `HOMEBREW_BREW_GIT_REMOTE` and/or `HOMEBREW_CORE_GIT_REMOTE` in your shell environment to use geolocalized Git mirrors to speed up Homebrew's installation with this script and, after installation, `brew update`.
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -754,10 +754,10 @@ then
   additional_shellenv_commands+=("export HOMEBREW_CORE_GIT_REMOTE=\"${HOMEBREW_CORE_GIT_REMOTE}\"")
 fi
 
-if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API-}" && -n "${HOMEBREW_INSTALL_FROM_API-}" ]]
+if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API-}" ]]
 then
-  ohai "HOMEBREW_INSTALL_FROM_API is set."
-  echo "Homebrew/homebrew-core will not be tapped during this ${tty_bold}install${tty_reset} run."
+  ohai "HOMEBREW_INSTALL_NO_FROM_API is set."
+  echo "Homebrew/homebrew-core will be tapped during this ${tty_bold}install${tty_reset} run."
 fi
 
 if [[ -z "${NONINTERACTIVE-}" ]]
@@ -914,18 +914,11 @@ ohai "Downloading and installing Homebrew..."
     fi
   fi
 
-  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API-}" && -n "${HOMEBREW_INSTALL_FROM_API-}" ]]
+  if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API-}" && ! -d "${HOMEBREW_CORE}" ]]
   then
+    # Always use single-quoted strings with `exp` expressions
     # shellcheck disable=SC2016
-    ohai 'Skip tapping homebrew/core because `$HOMEBREW_INSTALL_FROM_API` is set.'
-    # Unset HOMEBREW_DEVELOPER since it is no longer needed and causes warnings during brew update below
-    if [[ -n "${HOMEBREW_ON_LINUX-}" && (-n "${HOMEBREW_CURL_PATH-}" || -n "${HOMEBREW_GIT_PATH-}") ]]
-    then
-      export -n HOMEBREW_DEVELOPER
-    fi
-  elif [[ ! -d "${HOMEBREW_CORE}" ]]
-  then
-    ohai "Tapping homebrew/core"
+    ohai 'Tapping homebrew/core because `$HOMEBREW_NO_INSTALL_FROM_API` is set.'
     (
       execute "${MKDIR[@]}" "${HOMEBREW_CORE}"
       cd "${HOMEBREW_CORE}" >/dev/null || return

--- a/install.sh
+++ b/install.sh
@@ -756,7 +756,7 @@ fi
 
 if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API-}" ]]
 then
-  ohai "HOMEBREW_INSTALL_NO_FROM_API is set."
+  ohai "HOMEBREW_NO_INSTALL_FROM_API is set."
   echo "Homebrew/homebrew-core will be tapped during this ${tty_bold}install${tty_reset} run."
 fi
 


### PR DESCRIPTION
Now that this is the default, tweak the logic and messaging.

Do not merge until after 4.0.0 has been tagged.