### PR TITLE
Use `/home/${USER}` instead of `${HOME}`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,9 +112,11 @@ OS="$(uname)"
 if [[ "${OS}" == "Linux" ]]
 then
   HOMEBREW_ON_LINUX=1
+  USER_HOME="/home/${USER}"
 elif [[ "${OS}" == "Darwin" ]]
 then
   HOMEBREW_ON_MACOS=1
+  USER_HOME="/Users/${USER}"
 else
   abort "Homebrew is only supported on macOS and Linux."
 fi
@@ -136,7 +138,7 @@ then
     HOMEBREW_PREFIX="/usr/local"
     HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
   fi
-  HOMEBREW_CACHE="${HOME}/Library/Caches/Homebrew"
+  HOMEBREW_CACHE="${USER_HOME}/Library/Caches/Homebrew"
 
   STAT_PRINTF=("stat" "-f")
   PERMISSION_FORMAT="%A"
@@ -151,7 +153,7 @@ else
   # On Linux, this script installs to /home/linuxbrew/.linuxbrew only
   HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
   HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
-  HOMEBREW_CACHE="${HOME}/.cache/Homebrew"
+  HOMEBREW_CACHE="${USER_HOME}/.cache/Homebrew"
 
   STAT_PRINTF=("stat" "--printf")
   PERMISSION_FORMAT="%a"
@@ -986,18 +988,18 @@ EOS
 ohai "Next steps:"
 case "${SHELL}" in
   */bash*)
-    if [[ -r "${HOME}/.bash_profile" ]]
+    if [[ -r "${USER_HOME}/.bash_profile" ]]
     then
-      shell_profile="${HOME}/.bash_profile"
+      shell_profile="${USER_HOME}/.bash_profile"
     else
-      shell_profile="${HOME}/.profile"
+      shell_profile="${USER_HOME}/.profile"
     fi
     ;;
   */zsh*)
-    shell_profile="${HOME}/.zprofile"
+    shell_profile="${USER_HOME}/.zprofile"
     ;;
   *)
-    shell_profile="${HOME}/.profile"
+    shell_profile="${USER_HOME}/.profile"
     ;;
 esac
 


### PR DESCRIPTION
While trying to automate installing linuxbrew in an ansible playbook I noticed that all went well, apart from creating the `.cache` directory in the user's home.

This is because of multiple reasons:
1. To run in ansible I need it to `export NONINTERACTIVE=t`
2. To be able to execute it with sudo privileges through the ansible `become` functionality I need to already be root, and use sudo to switch back to the oriningal user.
3. It requires `-E` to preserve non-interactive
4. Because of this `-u` switches `${USER}` correctly but preserves `${HOME}` from `root`.

The workaround was to `export HOME=/home/{{ ansible_user_id }}` before execution, but honestly this should not be needed.

For reference, this is the ansible task that I wrote:

```yml
- name: Install homebrew
  ansible.builtin.shell: |
    set -eo pipefail

    export NONINTERACTIVE=1
    export HOME=/home/{{ ansible_user_id }}

    sudo -E -u {{ ansible_user_id }} `pwd`/install.sh
  args:
    chdir: '{{ homebrew_registered_repository_location.stdout }}'
  when: not homebrew_already_installed.stat.exists
  become: true
```

Unfortunately I could not find a better way to be able to automate this using ansible, reason why I'm proposing this change. If we replace the usage of `${HOME}` with `/home/${USER}` it should be identical to the current behaviour.