### PR TITLE
Check if Homebrew path evaluation statement is already in shell profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -998,7 +998,7 @@ esac
 if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew &>/dev/null
 then
   cat <<EOS
-- Homebrew was already found in your PATH, run this command to activate it in your current shell:
+- Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 elif ! grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"

--- a/install.sh
+++ b/install.sh
@@ -996,7 +996,7 @@ esac
 
 cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    grep -qsF 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' ${shell_profile} || (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
+    grep --quiet --no-messages --fixed-strings 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' ${shell_profile} || (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 if [[ -n "${non_default_repos}" ]]

--- a/install.sh
+++ b/install.sh
@@ -994,22 +994,16 @@ case "${SHELL}" in
     ;;
 esac
 
-# show different instructions on adding Homebrew to path based on if the user has already done so
-if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew &>/dev/null
+# don't show how to add Homebrew to path if the user has already done so
+if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
 then
-  cat <<EOS
-- Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
-EOS
-elif ! grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
-then
+  :
+else
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
     (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
-else
-  :
 fi
 
 if [[ -n "${non_default_repos}" ]]

--- a/install.sh
+++ b/install.sh
@@ -998,7 +998,7 @@ in_shell_profile=$(grep -s "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "
 
 # FIXME: figure out why this give a "command not found" error
 # show different instructions on adding Homebrew to path based on if the user has already done so
-if "${in_shell_profile}" && ! type brew &>/dev/null
+if [[ -n $in_shell_profile ]] && ! type brew &>/dev/null
 then
   cat <<EOS
 - Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:

--- a/install.sh
+++ b/install.sh
@@ -1001,7 +1001,7 @@ cat <<EOS
 - Homebrew was already found in your PATH, run this command to activate it in your current shell:
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
-elif ! grep -q "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
+elif ! grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
 then
 cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:

--- a/install.sh
+++ b/install.sh
@@ -994,7 +994,6 @@ case "${SHELL}" in
     ;;
 esac
 
-# show different instructions on adding Homebrew to path based on if the user has already done so
 if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
 then
   if ! [[ -x "$(command -v brew)" ]]

--- a/install.sh
+++ b/install.sh
@@ -995,7 +995,7 @@ case "${SHELL}" in
 esac
 
 # show different instructions if the user already has Homebrew in their PATH
-if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew >/dev/null 2>/dev/null
+if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew &>/dev/null
 then
 cat <<EOS
 - Homebrew was already found in your PATH, run this command to activate it in your current shell:

--- a/install.sh
+++ b/install.sh
@@ -997,19 +997,19 @@ esac
 # show different instructions on adding Homebrew to path based on if the user has already done so
 if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew &>/dev/null
 then
-cat <<EOS
+  cat <<EOS
 - Homebrew was already found in your PATH, run this command to activate it in your current shell:
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 elif ! grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
 then
-cat <<EOS
+  cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
     (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 else
-cat <<EOS
+  cat <<EOS
 - Homebrew is already set up. Your system is ready to brew.
 EOS
 fi

--- a/install.sh
+++ b/install.sh
@@ -994,25 +994,24 @@ case "${SHELL}" in
     ;;
 esac
 
-in_shell_profile=$(grep -s "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}")
-
-# FIXME: figure out why this give a "command not found" error
 # show different instructions on adding Homebrew to path based on if the user has already done so
-if [[ -n $in_shell_profile ]] && ! type brew &>/dev/null
+if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
 then
-  cat <<EOS
-- Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+  if ! type brew &>/dev/null
+  then
+    cat <<EOS
+    - Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
+      eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
-elif ! "${in_shell_profile}"
-then
-  cat <<EOS
-- Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
-    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
-EOS
+  else
+    :
+  fi
 else
-  :
+  cat <<EOS
+  - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
+      (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
+      eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+EOS
 fi
 
 if [[ -n "${non_default_repos}" ]]

--- a/install.sh
+++ b/install.sh
@@ -997,7 +997,7 @@ esac
 # show different instructions on adding Homebrew to path based on if the user has already done so
 if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
 then
-  if ! type brew &>/dev/null
+  if ! [[ -x "$(command -v brew)" ]]
   then
     cat <<EOS
     - Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:

--- a/install.sh
+++ b/install.sh
@@ -996,7 +996,7 @@ esac
 
 cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
+    grep -qsF 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' ${shell_profile} || (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 if [[ -n "${non_default_repos}" ]]

--- a/install.sh
+++ b/install.sh
@@ -994,14 +994,17 @@ case "${SHELL}" in
     ;;
 esac
 
+in_shell_profile=$(grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}")
+
+# FIXME: figure out why this give a "command not found" error
 # show different instructions on adding Homebrew to path based on if the user has already done so
-if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew &>/dev/null
+if "$in_shell_profile" && ! type brew &>/dev/null
 then
   cat <<EOS
 - Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
-elif ! grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
+elif ! "$in_shell_profile"
 then
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:

--- a/install.sh
+++ b/install.sh
@@ -994,16 +994,22 @@ case "${SHELL}" in
     ;;
 esac
 
-# don't show how to add Homebrew to path if the user has already done so
-if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
+# show different instructions on adding Homebrew to path based on if the user has already done so
+if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew &>/dev/null
 then
-  :
-else
+  cat <<EOS
+- Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
+    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+EOS
+elif ! grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
+then
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
     (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
+else
+  :
 fi
 
 if [[ -n "${non_default_repos}" ]]

--- a/install.sh
+++ b/install.sh
@@ -1009,9 +1009,7 @@ then
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 else
-  cat <<EOS
-- Homebrew is already set up. Your system is ready to brew.
-EOS
+  :
 fi
 
 if [[ -n "${non_default_repos}" ]]

--- a/install.sh
+++ b/install.sh
@@ -998,13 +998,13 @@ in_shell_profile=$(grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" 
 
 # FIXME: figure out why this give a "command not found" error
 # show different instructions on adding Homebrew to path based on if the user has already done so
-if "$in_shell_profile" && ! type brew &>/dev/null
+if "${in_shell_profile}" && ! type brew &>/dev/null
 then
   cat <<EOS
 - Run this command in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
-elif ! "$in_shell_profile"
+elif ! "${in_shell_profile}"
 then
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:

--- a/install.sh
+++ b/install.sh
@@ -995,17 +995,22 @@ case "${SHELL}" in
 esac
 
 # show different instructions if the user already has Homebrew in their PATH
-if grep -q "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
+if grep -q "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew >/dev/null 2>/dev/null
 then
 cat <<EOS
 - Homebrew was already found in your PATH, run this command to activate it in your current shell:
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
-else
+elif ! grep -q "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
+then
 cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
     (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+EOS
+else
+cat <<EOS
+- Homebrew is already set up. Your system is ready to brew.
 EOS
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -994,11 +994,22 @@ case "${SHELL}" in
     ;;
 esac
 
+# show different instructions if the user already has Homebrew in their PATH
+if grep -q "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}"
+then
 cat <<EOS
-- Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    grep --quiet --no-messages --fixed-strings 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' ${shell_profile} || (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
+- Homebrew was already found in your PATH, run this command to activate it in your current shell:
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
+else
+cat <<EOS
+- Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
+    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_profile}
+    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+EOS
+fi
+
+
 if [[ -n "${non_default_repos}" ]]
 then
   plural=""

--- a/install.sh
+++ b/install.sh
@@ -994,7 +994,7 @@ case "${SHELL}" in
     ;;
 esac
 
-# show different instructions if the user already has Homebrew in their PATH
+# show different instructions on adding Homebrew to path based on if the user has already done so
 if grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}" && ! type brew &>/dev/null
 then
 cat <<EOS

--- a/install.sh
+++ b/install.sh
@@ -994,7 +994,7 @@ case "${SHELL}" in
     ;;
 esac
 
-in_shell_profile=$(grep -qs "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}")
+in_shell_profile=$(grep -s "eval \"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)\"" "${shell_profile}")
 
 # FIXME: figure out why this give a "command not found" error
 # show different instructions on adding Homebrew to path based on if the user has already done so


### PR DESCRIPTION
Check if Homebrew is already in a user's `$PATH`. If it already is, then do not provide instructions to add it.