### PR TITLE
install.sh: ensure `master` is used for `git init`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -887,7 +887,7 @@ ohai "Downloading and installing Homebrew..."
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
 
   # we do it in four steps to avoid merge errors when reinstalling
-  execute "git" "init" "-q"
+  execute "git" "init" "--quiet" "--initial-branch" "master"
 
   # "git remote add" will fail if the remote is defined in the global config
   execute "git" "config" "remote.origin.url" "${HOMEBREW_BREW_GIT_REMOTE}"
@@ -923,7 +923,7 @@ ohai "Downloading and installing Homebrew..."
       execute "${MKDIR[@]}" "${HOMEBREW_CORE}"
       cd "${HOMEBREW_CORE}" >/dev/null || return
 
-      execute "git" "init" "-q"
+      execute "git" "init" "--quiet" "--initial-branch" "master"
       execute "git" "config" "remote.origin.url" "${HOMEBREW_CORE_GIT_REMOTE}"
       execute "git" "config" "remote.origin.fetch" "+refs/heads/*:refs/remotes/origin/*"
       execute "git" "config" "--bool" "core.autocrlf" "false"


### PR DESCRIPTION
This is not the case when `init.defaultBranch` is set to something else, like `main`. And in that case, if `HOMEBREW_DEVELOPER` is also set, the `Homebrew/brew` repository and `homebrew/core` (if tapped) will stay on that branch instead of `master` (and won't be updated anymore since there will be no tracking information available).

Also, for consistency, replace the short option `-q` with `--quiet`, the long one.