### PR TITLE
use initial-branch option for only git versions that support it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -887,7 +887,13 @@ ohai "Downloading and installing Homebrew..."
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
 
   # we do it in four steps to avoid merge errors when reinstalling
-  execute "git" "init" "--quiet" "--initial-branch" "master"
+
+  if grep -q initial-branch <(git init -h)
+  then
+    execute "git" "init" "--quiet"
+  else
+    execute "git" "init" "--quiet" "--initial-branch" "master"
+  fi
 
   # "git remote add" will fail if the remote is defined in the global config
   execute "git" "config" "remote.origin.url" "${HOMEBREW_BREW_GIT_REMOTE}"
@@ -923,7 +929,13 @@ ohai "Downloading and installing Homebrew..."
       execute "${MKDIR[@]}" "${HOMEBREW_CORE}"
       cd "${HOMEBREW_CORE}" >/dev/null || return
 
-      execute "git" "init" "--quiet" "--initial-branch" "master"
+      if grep -q initial-branch <(git init -h)
+      then
+        execute "git" "init" "--quiet" 
+      else
+        execute "git" "init" "--quiet" "--initial-branch" "master"
+      fi
+
       execute "git" "config" "remote.origin.url" "${HOMEBREW_CORE_GIT_REMOTE}"
       execute "git" "config" "remote.origin.fetch" "+refs/heads/*:refs/remotes/origin/*"
       execute "git" "config" "--bool" "core.autocrlf" "false"


### PR DESCRIPTION
Script fails on Ubuntu 20.04 LTS, and probably a lot more since a recent version of git (required for the git init --inital-branch option) is not listed as a installation dependency on [brew.sh](brew.sh)

Honestly suprised #747 merged without failing CI, suprised they only check for compatibility with latest and not oldest LTS, anyway

this just checks the option is available before using it.
