### PR TITLE
install.sh: override default branch config for `git init` invocations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -887,7 +887,7 @@ ohai "Downloading and installing Homebrew..."
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
 
   # we do it in four steps to avoid merge errors when reinstalling
-  execute "git" "init" "-q"
+  execute "git" "-c" "init.defaultBranch=master" "init" "--quiet"
 
   # "git remote add" will fail if the remote is defined in the global config
   execute "git" "config" "remote.origin.url" "${HOMEBREW_BREW_GIT_REMOTE}"
@@ -923,7 +923,7 @@ ohai "Downloading and installing Homebrew..."
       execute "${MKDIR[@]}" "${HOMEBREW_CORE}"
       cd "${HOMEBREW_CORE}" >/dev/null || return
 
-      execute "git" "init" "-q"
+      execute "git" "-c" "init.defaultBranch=master" "init" "--quiet"
       execute "git" "config" "remote.origin.url" "${HOMEBREW_CORE_GIT_REMOTE}"
       execute "git" "config" "remote.origin.fetch" "+refs/heads/*:refs/remotes/origin/*"
       execute "git" "config" "--bool" "core.autocrlf" "false"


### PR DESCRIPTION
Same as #747, but with a better approach which should be compatible with older versions of `git`. This makes sure `git init` always creates a `master` branch.

The same is being done at
https://github.com/Homebrew/brew/blob/76b87c4a00ed636bcf59c104b85863637609b66d/Library/Homebrew/dev-cmd/tap-new.rb#L162.

---

On a side note, @MikeMcQuaid mentioned in https://github.com/Homebrew/install/pull/747#issuecomment-1441774532:

> Similarly, may want to add CI for Ubuntu 18.04.

GitHub Actions will [drop](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md) their Ubuntu 18.04 runner image this April. And, all runner images provided by GitHub Actions seem to have a very recent version of Git installed. Maybe a Docker image like `buildpack-deps:18.04` could be used? Or, start from scratch with `ubuntu:18.04`.
