### PR TITLE
Fix `./bin` being in `$PATH`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -447,7 +447,7 @@ fi
 cd "/usr" || exit 1
 
 ####################################################################### script
-USABLE_GIT="$(command -v git)"
+USABLE_GIT="$(readlink -f "$(command -v git)")"
 if [[ -z "${USABLE_GIT}" ]]
 then
   abort "$(


### PR DESCRIPTION
# since when

Introduced in this commit:
https://github.com/Homebrew/install/commit/ce3f3e050e6afa4a9876a4d07fda889310dff977 @gromgit (you probably care about this)

# reproduce

To reproduce a failing install make sure that ./bin is in your path

```
export PATH="./bin:$PATH"
```

Then run the installer.

```
/bin/bash -c "$(curl -fsSL
https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```

It will fail like this

```
==> Downloading and installing Homebrew...
/bin/bash: line 234: ./bin/git: No such file or directory
Failed during: ./bin/git -c init.defaultBranch=master init --quiet
```

# why does it fail

Because when the installer checks for a git executable it is currently in the /usr directory.
See
https://github.com/Homebrew/install/blob/95648ef45c8d59a44fa4ab8f29cdcf17d6ec48ac/install.sh#L447

And in the /usr directory there is /usr/bin/git so the ``command -v``will find ``./bin/git`` and try to use that as git executable. See
https://github.com/Homebrew/install/blob/95648ef45c8d59a44fa4ab8f29cdcf17d6ec48ac/install.sh#L450

One could argue that having ./bin in PATH is a broken setup but its common to prio local binaries on a per project/folder basis. And I guess the whole point of the installer is to make it work on every system.

tl;dr

```
$ export PATH="./bin:$PATH"
$ cd /usr/
$ command -v git
./bin/git

```

# the fix

One could ensure that never a relative PATH is used by prefixing ``$USABLE_GIT`` with ``pwd`` but im not sure if that covers all edge cases and is the cleanest solution. I noticed that `command -V` prints the full path at least on my system (debian). Not sure how standard that is could some mac user verify that the fix works please?

The fix i went for is command -V instead of command -v

 ```
$ command -v git
./bin/git
$ command -V git
git is /usr/bin/git
$ command -V git | awk '{ print $3 }'
/usr/bin/git
 ```