### PR TITLE
Use xcode-select for CLDT detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,7 @@ should_install_command_line_tools() {
 
   if version_gt "${macos_version}" "10.13"
   then
-    ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]]
+    ! xcode-select -p &> /dev/null
   else
     ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]] ||
       ! [[ -e "/usr/include/iconv.h" ]]


### PR DESCRIPTION
CLDT is not required when Xcode is installed, as Xcode is a superset of CLDT. I think having both installed is just a waste of disk space.

This PR updates the installer to use the macOS' built-in `xcode-select` command rather than checking for a hardcoded path. `xcode-select -p` will return an error code if there is no CLDT or Xcode installed.