### PR TITLE
install: support OCI containers as root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -304,6 +304,7 @@ check_run_command_as_root() {
 
   # Allow Azure Pipelines/GitHub Actions/Docker/Concourse/Kubernetes to do everything as root (as it's normal there)
   [[ -f /.dockerenv ]] && return
+  [[ -f /run/.containerenv ]] && return
   [[ -f /proc/1/cgroup ]] && grep -E "azpl_job|actions_job|docker|garden|kubepods" -q /proc/1/cgroup && return
 
   abort "Don't run this as root!"


### PR DESCRIPTION
similar to the check for `/.dockerenv`, this adds a check for `/run/.containerenv`. if it exists, bypass the root user check. 

without this, you cannot execute this script as root in a container being managed by something like podman. it will always abort on line 310. 

see the [podman-run description](https://docs.podman.io/en/latest/markdown/podman-run.1.html#description) for more information about this file and my reasoning for including it. 