### PR TITLE
Upstream backport from AUR package installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -149,7 +149,7 @@ else
   UNAME_MACHINE="$(uname -m)"
 
   # On Linux, this script installs to /home/linuxbrew/.linuxbrew only
-  HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+  HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-"/home/linuxbrew/.linuxbrew"}"
   HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
   HOMEBREW_CACHE="${HOME}/.cache/Homebrew"
 

--- a/install.sh
+++ b/install.sh
@@ -941,7 +941,8 @@ ohai "Downloading and installing Homebrew..."
       execute "${USABLE_GIT}" "config" "--bool" "core.symlinks" "true"
       execute "${USABLE_GIT}" "fetch" "--force" "origin" "refs/heads/master:refs/remotes/origin/master"
       execute "${USABLE_GIT}" "remote" "set-head" "origin" "--auto" >/dev/null
-      execute "${USABLE_GIT}" "reset" "--hard" "origin/master"
+      HOMEBREW_INSTALL_VERSION="${HOMEBREW_INSTALL_VERSION:-origin/master}"
+      execute "${USABLE_GIT}" "reset" "--hard" "$HOMEBREW_INSTALL_VERSION"
 
       cd "${HOMEBREW_REPOSITORY}" >/dev/null || return
     ) || exit 1

--- a/install.sh
+++ b/install.sh
@@ -950,7 +950,7 @@ ohai "Downloading and installing Homebrew..."
   execute "${HOMEBREW_PREFIX}/bin/brew" "update" "--force" "--quiet"
 ) || exit 1
 
-if [[ ":${PATH}:" != *":${HOMEBREW_PREFIX}/bin:"* ]]
+if [[ ":${PATH}:" != *":${HOMEBREW_PREFIX}/bin:"* && -z "$HOMEBREW_SUPPRESS_PATH_WARNING" ]]
 then
   warn "${HOMEBREW_PREFIX}/bin is not in your PATH.
   Instructions on how to configure your shell for Homebrew

--- a/install.sh
+++ b/install.sh
@@ -941,7 +941,7 @@ ohai "Downloading and installing Homebrew..."
       execute "${USABLE_GIT}" "config" "remote.origin.fetch" "+refs/heads/*:refs/remotes/origin/*"
       execute "${USABLE_GIT}" "config" "--bool" "core.autocrlf" "false"
       execute "${USABLE_GIT}" "config" "--bool" "core.symlinks" "true"
-      execute "${USABLE_GIT}" "fetch" "--force" "origin" "refs/heads/master:refs/remotes/origin/master"
+      execute "${USABLE_GIT}" "fetch" --shallow-since=2022-01-01 "--force" "origin" "refs/heads/master:refs/remotes/origin/master"
       execute "${USABLE_GIT}" "remote" "set-head" "origin" "--auto" >/dev/null
       HOMEBREW_INSTALL_VERSION="${HOMEBREW_INSTALL_VERSION:-origin/master}"
       execute "${USABLE_GIT}" "reset" "--hard" "$HOMEBREW_INSTALL_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -954,6 +954,7 @@ ohai "Downloading and installing Homebrew..."
   execute "${HOMEBREW_PREFIX}/bin/brew" "update" "--force" "--quiet"
 ) || exit 1
 
+HOMEBREW_SUPPRESS_PATH_WARNING=${HOMEBREW_SUPPRESS_PATH_WARNING-}
 if [[ ":${PATH}:" != *":${HOMEBREW_PREFIX}/bin:"* && -z "$HOMEBREW_SUPPRESS_PATH_WARNING" ]]
 then
   warn "${HOMEBREW_PREFIX}/bin is not in your PATH.

--- a/install.sh
+++ b/install.sh
@@ -300,6 +300,7 @@ version_lt() {
 }
 
 check_run_command_as_root() {
+  [[ -z "$HOMEBREW_ROOT_OKIE_DOKIE" ]] || return 1
   [[ "${EUID:-${UID}}" == "0" ]] || return
 
   # Allow Azure Pipelines/GitHub Actions/Docker/Concourse/Kubernetes to do everything as root (as it's normal there)
@@ -482,6 +483,7 @@ EOABORT
 fi
 HOMEBREW_CORE="${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-core"
 
+HOMEBREW_ROOT_OKIE_DOKIE="$HOMEBREW_ROOT_OKIE_DOKIE"
 check_run_command_as_root
 
 if [[ -d "${HOMEBREW_PREFIX}" && ! -x "${HOMEBREW_PREFIX}" ]]

--- a/install.sh
+++ b/install.sh
@@ -299,6 +299,8 @@ version_lt() {
   [[ "${1%.*}" -lt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -lt "${2#*.}" ]]
 }
 
+HOMEBREW_ROOT_OKIE_DOKIE=${HOMEBREW_ROOT_OKIE_DOKIE-""}
+
 check_run_command_as_root() {
   [[ -z "$HOMEBREW_ROOT_OKIE_DOKIE" ]] || return 1
   [[ "${EUID:-${UID}}" == "0" ]] || return
@@ -483,7 +485,6 @@ EOABORT
 fi
 HOMEBREW_CORE="${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-core"
 
-HOMEBREW_ROOT_OKIE_DOKIE="$HOMEBREW_ROOT_OKIE_DOKIE"
 check_run_command_as_root
 
 if [[ -d "${HOMEBREW_PREFIX}" && ! -x "${HOMEBREW_PREFIX}" ]]


### PR DESCRIPTION
All changes non-breaking.

Closes #770.
Closes #771.
https://github.com/Homebrew/install/commit/767c59a1eddc64576747a410b2d57189c7c0168d allows to pass `HOMEBREW_ROOT_OKIE_DOKIE` which allows running installer as root, fakeroot or not.
https://github.com/Homebrew/install/commit/01166f23f6f91b923b21ca8bd5a4d353ca6b7114 is just a common sense bandwidth save.