### PR TITLE
Fix `./bin` being in `$PATH` (mac)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -833,28 +833,29 @@ EOABORT
   )"
 fi
 
-USABLE_GIT="$(command -v git)"
-if [[ -z "${USABLE_GIT}" ]]
+USABLE_GIT=/usr/bin/git
+if [[ -n "${HOMEBREW_ON_LINUX-}" ]]
 then
-  abort "$(
-    cat <<EOABORT
-You must install Git before installing Homebrew. See:
-  ${tty_underline}https://docs.brew.sh/Installation${tty_reset}
-EOABORT
-  )"
-elif [[ -n "${HOMEBREW_ON_LINUX-}" ]]
-then
-  suitable_git="$(find_tool git)"
-  if [[ -z "${suitable_git}" ]]
+  USABLE_GIT="$(find_tool git)"
+  git_installed="$(command -v git)"
+  if [[ -z "${git_installed}" ]]
   then
     abort "$(
       cat <<EOABORT
-The version of Git that was found does not satisfy requirements for Homebrew.
-Please install Git ${REQUIRED_GIT_VERSION} or newer and add it to your PATH.
+  You must install Git before installing Homebrew. See:
+    ${tty_underline}https://docs.brew.sh/Installation${tty_reset}
 EOABORT
     )"
   fi
-  USABLE_GIT="${suitable_git}"
+  if [[ -z "${USABLE_GIT}" ]]
+  then
+    abort "$(
+      cat <<EOABORT
+  The version of Git that was found does not satisfy requirements for Homebrew.
+  Please install Git ${REQUIRED_GIT_VERSION} or newer and add it to your PATH.
+EOABORT
+    )"
+  fi
   if [[ "${USABLE_GIT}" != /usr/bin/git ]]
   then
     export HOMEBREW_GIT_PATH="${USABLE_GIT}"

--- a/install.sh
+++ b/install.sh
@@ -837,8 +837,7 @@ USABLE_GIT=/usr/bin/git
 if [[ -n "${HOMEBREW_ON_LINUX-}" ]]
 then
   USABLE_GIT="$(find_tool git)"
-  git_installed="$(command -v git)"
-  if [[ -z "${git_installed}" ]]
+  if [[ -z "$(command -v git)" ]]
   then
     abort "$(
       cat <<EOABORT


### PR DESCRIPTION
https://github.com/Homebrew/install/pull/774 broke https://github.com/Homebrew/install/pull/756 for mac.

Thanks to @Bo98 for [reporting](https://github.com/Homebrew/install/pull/774#issuecomment-1555142496)

So my fix for the fix in the fix that fixed a bug in the previous fix had a bug. This probably introduces a new bug. Hard to tell without proper test coverage.