### PR TITLE
Add support to install as $INSTALL_USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ If you want to run the Homebrew installer non-interactively without prompting fo
 NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
+If you want to run the Homebrew installer as root whithout prompting for passwords, while installing for a non-root user, you can use:
+
+```bash
+INSTALL_USER=<user> /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
 ## Uninstall Homebrew
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to run the Homebrew installer non-interactively without prompting fo
 NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-If you want to run the Homebrew installer as root whithout prompting for passwords, while installing for a non-root user, you can use:
+If you want to run the Homebrew installer as root without prompting for passwords, while installing for a non-root user, you can use:
 
 ```bash
 INSTALL_USER=<user> /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/install.sh
+++ b/install.sh
@@ -109,6 +109,11 @@ fi
 
 # Allow delegating installation to a different user (useful for installs by root)
 INSTALL_USER="${INSTALL_USER-${USER}}"
+if ! INSTALL_USER_UID=$(id -u "${INSTALL_USER}")
+then
+  abort "INSTALL_USER '${INSTALL_USER}' does not exist"
+fi
+
 INSTALL_HOME=$(eval echo ~"${INSTALL_USER}")
 
 # First check OS.
@@ -316,7 +321,6 @@ version_lt() {
 }
 
 check_run_command_as_root() {
-  INSTALL_USER_UID=$(id -u "${INSTALL_USER}")
   if [[ "${INSTALL_USER_UID}" != "0" ]]
   then
     ohai "Installing homebrew for user ${INSTALL_USER}"

--- a/install.sh
+++ b/install.sh
@@ -108,8 +108,8 @@ then
 fi
 
 # Allow delegating installation to a different user (useful for installs by root)
-INSTALL_USER="${INSTALL_USER-$USER}"
-INSTALL_HOME=$(eval echo ~"$INSTALL_USER")
+INSTALL_USER="${INSTALL_USER-${USER}}"
+INSTALL_HOME=$(eval echo ~"${INSTALL_USER}")
 
 # First check OS.
 OS="$(uname)"
@@ -316,10 +316,10 @@ version_lt() {
 }
 
 check_run_command_as_root() {
-  INSTALL_USER_UID=$(id -u $INSTALL_USER)
-  if [[ "$INSTALL_USER_UID" != "0" ]]
+  INSTALL_USER_UID=$(id -u "${INSTALL_USER}")
+  if [[ "${INSTALL_USER_UID}" != "0" ]]
   then
-    ohai "Installing homebrew for user $INSTALL_USER"
+    ohai "Installing homebrew for user ${INSTALL_USER}"
     return
   fi
 


### PR DESCRIPTION
Allow to install as another user:

```
INSTALL_USER=ellis /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/berikv/homebrew_install/master/install.sh)"
```

This is especially useful in headless installs by root, where passing a sudo password would make the install script insecure and / or needlessly complex.

setup_machine.sh // Run as root
```
...
INSTALL_USER=NoAdmin /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/berikv/homebrew_install/master/install.sh)"
...
```

Tested on Intel MacOS 13.4.1:

* Root delegate to user, allowed
* User delegate to other user, allowed
* User delegate to root, disallowed
