### PR TITLE
doc: add `install.sh --help`. Fix #790

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,29 @@ then
   abort 'Bash must not run in POSIX mode. Please unset POSIXLY_CORRECT and try again.'
 fi
 
+usage() {
+  cat <<EOS
+Homebrew Installer
+Usage: [NONINTERACTIVE=1] [CI=1] $0 [options]
+    -h, --help       Display this message.
+    NONINTERACTIVE   Install without prompting.
+    CI               Imply NONINTERACTIVE.
+EOS
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]
+do
+  case "$1" in
+    -h | --help) usage ;;
+    *)
+      warn "Unrecognized option: '$1'"
+      usage 1
+      ;;
+  esac
+  # shift # Command appears to be unreachable. Check usage (or ignore if invoked indirectly). shellcheck (SC2317)
+done
+
 # string formatters
 if [[ -t 1 ]]
 then

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ fi
 usage() {
   cat <<EOS
 Homebrew Installer
-Usage: [NONINTERACTIVE=1] [CI=1] $0 [options]
+Usage: [NONINTERACTIVE=1] [CI=1] install.sh [options]
     -h, --help       Display this message.
     NONINTERACTIVE   Install without prompting for user input
     CI               Imply NONINTERACTIVE.

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ usage() {
 Homebrew Installer
 Usage: [NONINTERACTIVE=1] [CI=1] $0 [options]
     -h, --help       Display this message.
-    NONINTERACTIVE   Install without prompting.
+    NONINTERACTIVE   Install without prompting for user input
     CI               Imply NONINTERACTIVE.
 EOS
   exit "${1:-0}"

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ Homebrew Installer
 Usage: [NONINTERACTIVE=1] [CI=1] install.sh [options]
     -h, --help       Display this message.
     NONINTERACTIVE   Install without prompting for user input
-    CI               Imply NONINTERACTIVE.
+    CI               Install in CI mode (e.g. do not prompt for user input)
 EOS
   exit "${1:-0}"
 }

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,6 @@ do
       usage 1
       ;;
   esac
-  # shift # Command appears to be unreachable. Check usage (or ignore if invoked indirectly). shellcheck (SC2317)
 done
 
 # string formatters


### PR DESCRIPTION
Adapted from `uninstall.sh`:

```console
$ ./install.sh --help
Homebrew Installer
Usage: [NONINTERACTIVE=1] [CI=1] ./install.sh [options]
    -h, --help       Display this message.
    NONINTERACTIVE   Install without prompting.
    CI               Imply NONINTERACTIVE.
$ ./install.sh -h    
Homebrew Installer
Usage: [NONINTERACTIVE=1] [CI=1] ./install.sh [options]
    -h, --help       Display this message.
    NONINTERACTIVE   Install without prompting.
    CI               Imply NONINTERACTIVE.
$ ./install.sh --foo
Warning: Unrecognized option: '--foo'
Homebrew Installer
Usage: [NONINTERACTIVE=1] [CI=1] ./install.sh [options]
    -h, --help       Display this message.
    NONINTERACTIVE   Install without prompting.
    CI               Imply NONINTERACTIVE.
```

I didn't modify the README since it already mentions the only supported option.

ShellCheck complained about the `shift` (unreachable), so I commented it out. I didn't remove it to make it easier in case a new option gets added in the future.

The ShellCheck warning:

```
$ shellcheck install.sh 

In install.sh line 99:
  shift # Command appears to be unreachable. Check usage (or ignore if invoked indirectly). shellcheck (SC2317)
  ^-- SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

For more information:
  https://www.shellcheck.net/wiki/SC2317 -- Command appears to be unreachable...
```

---

Note: I assumed `CI` and `NONINTERACTIVE` are interchangeable. There was a closed issue that was solved by setting `CI=1` and I don't know if `NONINTERACTIVE=1` would have worked as well.
- https://github.com/Homebrew/install/issues/369

If they are equivalent, should `CI` be added to `uninstall.sh` for consistency?