### PR TITLE
Delete legacy unused issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,1 +1,0 @@
-# Please fill out one of the templates on: https://github.com/Homebrew/install/issues/new/choose or we will close it without comment.


### PR DESCRIPTION
The `issue_template.md` file is not used if `blank_issues_enabled: false` is set: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser