### PR TITLE
install.sh: Condense (grep | awk | sed) to awk only

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -817,9 +817,7 @@ then
   execute_sudo "${TOUCH[@]}" "${clt_placeholder}"
 
   clt_label_command="/usr/sbin/softwareupdate -l |
-                      grep -B 1 -E 'Command Line Tools' |
-                      awk -F'*' '/^ *\\*/ {print \$2}' |
-                      sed -e 's/^ *Label: //' -e 's/^ *//' |
+                      awk '/Label:[[:blank:]]+Command Line Tools/ {\$1=\$1; sub(/^.*Label:[[:blank:]]+/,\"\"); print; next}' |
                       sort -V |
                       tail -n1"
   clt_label="$(chomp "$(/bin/bash -c "${clt_label_command}")")"


### PR DESCRIPTION
Condense (grep | awk | sed) to awk only.

Awk can find and substitute, too.

---
Explanation:
We combine the functionality of the `grep` (find, match) and `sed` (in this case, substitute) into `awk` itself. `awk` was being used anyway, so it made me wonder why bother doing things with other tools when `awk` can also do those same things.

When assigning a value to a field variable--in this case field `$1` is "assigned" the value of itself--awk recompiles the record (field `$0`) by concatenating all of the fields with the output field separator (OFS), which is space by default. This will also remove all leading and trailing spaces from the record when using the default FS. (https://unix.stackexchange.com/questions/568666/how-does-awk-1-1-remove-extra-spaces)