### PR TITLE
install: add fish post install instructions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1029,6 +1029,9 @@ case "${SHELL}" in
       shell_rcfile="${ZDOTDIR:-"${HOME}"}/.zprofile"
     fi
     ;;
+  */fish*)
+    shell_rcfile="${HOME}/.config/fish/config.fish"
+    ;;
   *)
     shell_rcfile="${ENV:-"${HOME}/.profile"}"
     ;;


### PR DESCRIPTION
This adds the correct config file for the fish shell needed to load the brew environment. Fish ends up using the `~/.config/fish/config.fish` file during startup to load environment variables and scripts most of the time. This is also used by asdf and ghcup for instance.

This was brought up in discussion here:
- https://github.com/orgs/Homebrew/discussions/4412
- https://github.com/orgs/Homebrew/discussions/4722

More info:
- https://fishshell.com/docs/current/index.html#configuration