### PR TITLE
install.sh: don't set `HOMEBREW_DEVELOPER`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -910,13 +910,6 @@ EOABORT
   fi
 fi
 
-# Set HOMEBREW_DEVELOPER on Linux systems where usable Git/cURL is not in /usr/bin
-if [[ -n "${HOMEBREW_ON_LINUX-}" && (-n "${HOMEBREW_CURL_PATH-}" || -n "${HOMEBREW_GIT_PATH-}") ]]
-then
-  ohai "Setting HOMEBREW_DEVELOPER to use Git/cURL not in /usr/bin"
-  export HOMEBREW_DEVELOPER=1
-fi
-
 ohai "Downloading and installing Homebrew..."
 (
   cd "${HOMEBREW_REPOSITORY}" >/dev/null || return


### PR DESCRIPTION
We don't want to trip people into HOMEBREW_DEVELOPER features right away (e.g. Ruby 3).

This hack is also no longer necessary since https://github.com/Homebrew/brew/commit/77203e0760fea53ee19019527bf87a997780a0a8.