### PR TITLE
fix - changes in the install.sh for misplaced single quote.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1042,7 +1042,7 @@ EOS
 else
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_rcfile}
+    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)")' >> ${shell_rcfile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 fi


### PR DESCRIPTION
A single quote was misplaced in the section of `Run these two commands in your terminal to add Homebrew`
Fixing this will make the post install process run smoothly without any hiccup.