### PR TITLE
README.md: Add instructions on how to uninstall from a specific prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,11 @@ If you want to run the Homebrew uninstaller non-interactively, you can use:
 NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 ```
 
-Download the uninstall script and run `/bin/bash uninstall.sh --help` to view more uninstall options.
+If you want to to uninstall Homebrew from a specific prefix (e.g. when migrating from Intel to Apple Silicon processors), download the uninstall script and run it with `--path`:
+
+```
+curl -fsSLO https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh
+/bin/bash uninstall.sh --path /usr/local
+```
+
+Run the downloaded script with `/bin/bash uninstall.sh --help` to view more uninstall options.


### PR DESCRIPTION
Follows-up https://github.com/Homebrew/install/issues/816#issuecomment-1805291353:

> > By default it uninstalls the default Homebrew, https://github.com/Homebrew/install?tab=readme-ov-file#uninstall-homebrew suggests running it with --help though. That shows how to "cleanup Homebrew whether it is installed into /usr/local/bin or /opt/homebrew independently of the native arch"
>
> I could see an argument that some of the uninstall options could be spelled out in the README so am rescoping this issue to that goal.

Closes https://github.com/Homebrew/install/issues/816.