### PR TITLE
Update install.sh to allow repeated execution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1048,7 +1048,7 @@ EOS
 else
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_rcfile}
+    grep -qxF 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' /Users/$(id -un)/.zprofile || (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> /Users/$(id -un)/.zprofile
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 fi


### PR DESCRIPTION
This change to the script does two things:

1. It automatically gets user name
2. It allows repeated execution (does not add a line to .zprofile twice, so it will not grow out of control)

## Workaround

As a work around I have to create my own installation script:

```sh
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
grep -qxF 'eval "$(/opt/homebrew/bin/brew shellenv)"' /Users/$(id -un)/.zprofile || (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> /Users/$(id -un)/.zprofile
eval "$(/opt/homebrew/bin/brew shellenv)"
```