### PR TITLE
install.sh: use `printf` to print post-install instructions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1048,7 +1048,7 @@ EOS
 else
   cat <<EOS
 - Run these two commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    (echo; echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"') >> ${shell_rcfile}
+    printf '%s\n' '' 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_rcfile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS
 fi


### PR DESCRIPTION
In Fish shell, parentheses are for command substitution, so the parenthesised subshell used for `echo` grouping does not work there. Instead let's use `printf` to print the post-install instructions; it's more portable.

Fixes #880.
