### PR TITLE
Make some git invocations quiet

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -927,8 +927,8 @@ ohai "Downloading and installing Homebrew..."
   # make sure symlinks are saved as-is
   execute "${USABLE_GIT}" "config" "--bool" "core.symlinks" "true"
 
-  execute "${USABLE_GIT}" "fetch" "--force" "origin"
-  execute "${USABLE_GIT}" "fetch" "--force" "--tags" "origin"
+  execute "${USABLE_GIT}" "fetch" "--quiet" "--progress" "--force" "origin"
+  execute "${USABLE_GIT}" "fetch" "--quiet" "--progress" "--force" "--tags" "origin"
   execute "${USABLE_GIT}" "remote" "set-head" "origin" "--auto" >/dev/null
 
   LATEST_GIT_TAG="$("${USABLE_GIT}" tag --list --sort="-version:refname" | head -n1)"
@@ -936,7 +936,7 @@ ohai "Downloading and installing Homebrew..."
   then
     abort "Failed to query latest Homebrew/brew Git tag."
   fi
-  execute "${USABLE_GIT}" "checkout" "--force" "-B" "stable" "${LATEST_GIT_TAG}"
+  execute "${USABLE_GIT}" "checkout" "--quiet" "--force" "-B" "stable" "${LATEST_GIT_TAG}"
 
   if [[ "${HOMEBREW_REPOSITORY}" != "${HOMEBREW_PREFIX}" ]]
   then
@@ -962,7 +962,8 @@ ohai "Downloading and installing Homebrew..."
       execute "${USABLE_GIT}" "config" "remote.origin.fetch" "+refs/heads/*:refs/remotes/origin/*"
       execute "${USABLE_GIT}" "config" "--bool" "core.autocrlf" "false"
       execute "${USABLE_GIT}" "config" "--bool" "core.symlinks" "true"
-      execute "${USABLE_GIT}" "fetch" "--force" "origin" "refs/heads/master:refs/remotes/origin/master"
+      execute "${USABLE_GIT}" "fetch" "--force" "--quiet" "--progress" \
+                                      "origin" "refs/heads/master:refs/remotes/origin/master"
       execute "${USABLE_GIT}" "remote" "set-head" "origin" "--auto" >/dev/null
       execute "${USABLE_GIT}" "reset" "--hard" "origin/master"
 


### PR DESCRIPTION
Currently, all the branches and tags are printed out by `git fetch`, which I believe our end users are not concerned about.

This change suppresses some of the Git outputs with the `--quiet` option, so no branches or tags are printed out. As the progress bar can still be useful, `--progress` is used to keep it enabled.
