### PR TITLE
move install suggestion from yum to dnf, update syntax

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1082,9 +1082,9 @@ then
   if [[ -x "$(command -v apt-get)" ]]
   then
     echo "    sudo apt-get install build-essential"
-  elif [[ -x "$(command -v yum)" ]]
+  elif [[ -x "$(command -v dnf)" ]]
   then
-    echo "    sudo yum groupinstall 'Development Tools'"
+    echo "    sudo dnf groupinstall development-tools"
   elif [[ -x "$(command -v pacman)" ]]
   then
     echo "    sudo pacman -S base-devel"

--- a/install.sh
+++ b/install.sh
@@ -1084,7 +1084,10 @@ then
     echo "    sudo apt-get install build-essential"
   elif [[ -x "$(command -v dnf)" ]]
   then
-    echo "    sudo dnf groupinstall development-tools"
+    echo "    sudo dnf group install development-tools"
+  elif [[ -x "$(command -v yum)" ]]
+  then
+    echo "    sudo yum groupinstall 'Development Tools'"
   elif [[ -x "$(command -v pacman)" ]]
   then
     echo "    sudo pacman -S base-devel"


### PR DESCRIPTION
For Fedora/RHEL Linux, yum was replaced by the dnf package manager in 2015.