### PR TITLE
Remove redundant escape characters

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -492,7 +492,7 @@ elif ! [[ -w "${HOMEBREW_PREFIX}" ]] &&
 then
   abort "$(
     cat <<EOABORT
-Insufficient permissions to install Homebrew to \"${HOMEBREW_PREFIX}\" (the default prefix).
+Insufficient permissions to install Homebrew to "${HOMEBREW_PREFIX}" (the default prefix).
 
 Alternative (unsupported) installation methods are available at:
 https://docs.brew.sh/Installation#alternative-installs


### PR DESCRIPTION
Since we write the insufficient permissions message in a heredoc, the `\"` characters are rendered as-is instead of as an escaped quote character.

Before:

```
Insufficient permissions to install Homebrew to \"/home/linuxbrew/.linuxbrew\" (the default prefix).
```

After:

```
Insufficient permissions to install Homebrew to "/home/linuxbrew/.linuxbrew" (the default prefix).
```