### PR TITLE
install.sh: ignore curl snap if found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -393,6 +393,12 @@ test_curl() {
     return 1
   fi
 
+  if [[ "$1" == "/snap/bin/curl" ]]
+  then
+    warn "Ignoring $1 (curl snap is too restricted)"
+    return 1
+  fi
+
   local curl_version_output curl_name_and_version
   curl_version_output="$("$1" --version 2>/dev/null)"
   curl_name_and_version="${curl_version_output%% (*}"


### PR DESCRIPTION
Snap upstream [refuses to relax strict security confinement](https://forum.snapcraft.io/t/classic-confinement-request-for-curl/24611/13) on curl. This breaks the install process, as at least two different reports reveal: https://github.com/Homebrew/install/issues/840 https://github.com/orgs/Homebrew/discussions/5776#discussioncomment-11427538

This patch also warns the user about this rejection, because the curl snap is quite likely the only curl installed on a user's system _and_ is otherwise recent enough to pass the version test, so it provides the necessary clarification to the next thing the user sees:
```
The version of cURL that was found does not satisfy requirements for Homebrew.
Please install cURL ${REQUIRED_CURL_VERSION} or newer and add it to your PATH.
```
