### PR TITLE
install.sh: update comment for non-default Git remote setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1076,7 +1076,7 @@ then
     plural="s"
   fi
   printf -- "- Run these commands in your terminal to add the non-default Git remote%s for %s:\n" "${plural}" "${non_default_repos}"
-  printf "    echo '# Set PATH, MANPATH, etc., for Homebrew.' >> %s\n" "${shell_rcfile}"
+  printf "    echo '# Set non-default Git remote%s for %s.' >> %s\n" "${plural}" "${non_default_repos}" "${shell_rcfile}"
   printf "    echo '%s' >> ${shell_rcfile}\n" "${additional_shellenv_commands[@]}"
   printf "    %s\n" "${additional_shellenv_commands[@]}"
 fi


### PR DESCRIPTION
The existing comment is wrong, the commands are not for setting up PATHs:

```
- Run these commands in your terminal to add the non-default Git remote for Homebrew/brew:
    echo '# Set PATH, MANPATH, etc., for Homebrew.' >> /Users/ruoyu/.zprofile
    echo 'export HOMEBREW_BREW_GIT_REMOTE="https://example.org/brew.git"' >> /Users/ruoyu/.zprofile
    export HOMEBREW_BREW_GIT_REMOTE="https://example.org/brew.git"
```

With this change, the comment is updated to reflect the correct purpose of the commands:

```
- Run these commands in your terminal to add the non-default Git remote for Homebrew/brew:
    echo '# Set non-default Git remote for Homebrew/brew.' >> /Users/ruoyu/.zprofile
    echo 'export HOMEBREW_BREW_GIT_REMOTE="https://example.org/brew.git"' >> /Users/ruoyu/.zprofile
    export HOMEBREW_BREW_GIT_REMOTE="https://example.org/brew.git"
```
