### PR TITLE
tests.yml: tighten actions/checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Cleanup macOS
         if: runner.os == 'macOS'


### PR DESCRIPTION
Tighten our use of `actions/checkout` as we do not need to retain the credentials after checkout.