### PR TITLE
uninstall.sh: prevent deleting none related homebrew files

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -462,6 +462,8 @@ fi
 dir_children "${HOMEBREW_REPOSITORY}" "${HOMEBREW_PREFIX}" |
   sort -u >"${tmpdir}/residual_files"
 
+grep -v "MacGPG2" "${tmpdir}/residual_files" >"${tmpdir}/filtered_residual_files"
+
 if [[ -s "${tmpdir}/residual_files" && -z "${opt_quiet}" ]]
 then
   echo "The following possible Homebrew files were not deleted:"


### PR DESCRIPTION
I uninstalled homebrew because of a problem. 
Uninstaller prompted me to delete: `/usr/local/MacGPG2/` which isn't a Homebrew related file so skip it to be shown on none deleted directories and files by the script.