### PR TITLE
uninstall.sh: don't check /usr/local for residual files

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -459,7 +459,7 @@ then
   fi
 fi
 
-residual_dirs=("${HOMEREW_REPOSITORY}")
+residual_dirs=("${HOMEBREW_REPOSITORY}")
 if [[ "${HOMEBREW_PREFIX}" != "/usr/local" ]]
 then
   residual_dirs+=("${HOMEBREW_PREFIX}")

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -459,7 +459,12 @@ then
   fi
 fi
 
-dir_children "${HOMEBREW_REPOSITORY}" "${HOMEBREW_PREFIX}" |
+residual_dirs=("${HOMEREW_REPOSITORY}")
+if [[ "${HOMEBREW_PREFIX}" != "/usr/local" ]]
+then
+  residual_dirs+=("${HOMEBREW_PREFIX}")
+fi
+dir_children "${residual_dirs[@]}" |
   sort -u >"${tmpdir}/residual_files"
 
 if [[ -s "${tmpdir}/residual_files" && -z "${opt_quiet}" ]]


### PR DESCRIPTION
It's a very common install prefix, so any residual files found here are likely false positives.

Followup to #923.