### PR TITLE
userspecified install prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ If you're on macOS, try out our new `.pkg` installer. Download it from [Homebrew
 If you are running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).
 
 You can set `HOMEBREW_NO_INSTALL_FROM_API` to tap Homebrew/homebrew-core; by default, it will not be tapped as it is no longer necessary.
-
+To install Homebrew to a user-specified directory, use `HOMEBREW_INSTALL_PREFIX` like so:
+```bash
+HOMEBREW_INSTALL_PREFIX='/where/to/install/homebrew' curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+````
 You can set `HOMEBREW_BREW_GIT_REMOTE` and/or `HOMEBREW_CORE_GIT_REMOTE` in your shell environment to use geolocalized Git mirrors to speed up Homebrew's installation with this script and, after installation, `brew update`.
 
 ```bash
@@ -42,7 +45,7 @@ If you want to run the Homebrew uninstaller non-interactively, you can use:
 NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 ```
 
-If you want to to uninstall Homebrew from a specific prefix (e.g. when migrating from Intel to Apple Silicon processors), download the uninstall script and run it with `--path`:
+If you want to uninstall Homebrew from a specific prefix (e.g. when migrating from Intel to Apple Silicon processors), download the uninstall script and run it with `--path`:
 
 ```
 curl -fsSLO https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh

--- a/install.sh
+++ b/install.sh
@@ -79,8 +79,9 @@ warn() {
 usage() {
   cat <<EOS
 Homebrew Installer
-Usage: [NONINTERACTIVE=1] [CI=1] install.sh [options]
+Usage: [HOMEBREW_INSTALL_PREFIX] [NONINTERACTIVE=1] [CI=1] install.sh [options]
     -h, --help       Display this message.
+    HOMEBREW_INSTALL_PREFIX   Specify where to install Homebrew. If unspecified, the defaults will be used.
     NONINTERACTIVE   Install without prompting for user input
     CI               Install in CI mode (e.g. do not prompt for user input)
 EOS
@@ -129,6 +130,16 @@ then
   export USER
 fi
 
+#
+# Support the specification of a user-specified install # prefix.
+# Set a flag variable that will be referenced later to its default value.
+HOMEBREW_USERSPECIFIED_INSTALL_PREFIX=0
+if [[ -n "${HOMEBREW_INSTALL_PREFIX-}" ]]
+then
+  # A prefix got passed in, so let's set the flag.
+  HOMEBREW_USERSPECIFIED_INSTALL_PREFIX=1
+fi
+# 
 # First check OS.
 OS="$(uname)"
 if [[ "${OS}" == "Linux" ]]
@@ -141,21 +152,36 @@ else
   abort "Homebrew is only supported on macOS and Linux."
 fi
 
-# Required installation paths. To install elsewhere (which is unsupported)
-# you can untar https://github.com/Homebrew/brew/tarball/master
-# anywhere you like.
 if [[ -n "${HOMEBREW_ON_MACOS-}" ]]
 then
   UNAME_MACHINE="$(/usr/bin/uname -m)"
 
   if [[ "${UNAME_MACHINE}" == "arm64" ]]
   then
-    # On ARM macOS, this script installs to /opt/homebrew only
-    HOMEBREW_PREFIX="/opt/homebrew"
+    # On ARM macOS, this script installs to
+    # /opt/homebrew if not user-specified.
+    HOMEBREW_PREFIX_DEFAULT="/opt/homebrew"
+    if [[ "${HOMEBREW_USERSPECIFIED_INSTALL_PREFIX}" == 1 ]]
+    then
+      # The user wants to install Homebrew somewhere else entirely.
+      HOMEBREW_PREFIX="${HOMEBREW_INSTALL_PREFIX}"
+    else
+      # Use the default instead.
+      HOMEBREW_PREFIX="${HOMEBREW_PREFIX_DEFAULT}"
+    fi
     HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}"
   else
-    # On Intel macOS, this script installs to /usr/local only
-    HOMEBREW_PREFIX="/usr/local"
+    # On Intel macOS, this script installs to /usr/local
+    # if not user-specified.
+    HOMEBREW_PREFIX_DEFAULT="/usr/local"
+    if [[ "${HOMEBREW_USERSPECIFIED_INSTALL_PREFIX}" == 1 ]]
+    then
+      # The user wants to install Homebrew somewhere else entirely.
+      HOMEBREW_PREFIX="${HOMEBREW_INSTALL_PREFIX}"
+    else
+      # Use the default instead.
+      HOMEBREW_PREFIX="${HOMEBREW_PREFIX_DEFAULT}"
+    fi
     HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
   fi
   HOMEBREW_CACHE="${HOME}/Library/Caches/Homebrew"


### PR DESCRIPTION
- **Install: allow the user to specify an install prefix.**
- **install: modify variable names to more closely match the uninstaller.**
- **install: fix variable interpolation, make sure the flag variable has a default value.**
- **install: remove comment.**
- **README: remove duplicate word.**
- **README: document how to use HOMEBREW_INSTALL_PREFIX.**
