### PR TITLE
Allow non-admin user installs on macOS if prefix is user-writable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -225,6 +225,11 @@ have_sudo_access() {
     return 1
   fi
 
+  if [[ -n "${HOMEBREW_ON_MACOS-}" ]] && [[ -w "${HOMEBREW_PREFIX}" ]]
+  then
+    return 1
+  fi
+
   local -a SUDO=("/usr/bin/sudo")
   if [[ -n "${SUDO_ASKPASS-}" ]]
   then
@@ -247,7 +252,17 @@ have_sudo_access() {
 
   if [[ -n "${HOMEBREW_ON_MACOS-}" ]] && [[ "${HAVE_SUDO_ACCESS}" -ne 0 ]]
   then
-    abort "Need sudo access on macOS (e.g. the user ${USER} needs to be an Administrator)!"
+    abort "$(cat <<EOABORT
+Need sudo access on macOS (e.g. the user ${USER} needs to be an Administrator)!
+
+If you want to use Homebrew from a standard (non-admin) macOS account without sudo, run these commands using an admin account:
+
+  sudo mkdir -p "${HOMEBREW_PREFIX}"
+  sudo chown -R "${USER}:${GROUP}" "${HOMEBREW_PREFIX}"
+
+Then you can rerun this script entirely without admin privileges.
+EOABORT
+    )"
   fi
 
   return "${HAVE_SUDO_ACCESS}"

--- a/install.sh
+++ b/install.sh
@@ -252,15 +252,16 @@ have_sudo_access() {
 
   if [[ -n "${HOMEBREW_ON_MACOS-}" ]] && [[ "${HAVE_SUDO_ACCESS}" -ne 0 ]]
   then
-    abort "$(cat <<EOABORT
+    abort "$(
+      cat <<EOABORT
 Need sudo access on macOS (e.g. the user ${USER} needs to be an Administrator)!
 
-If you want to use Homebrew from a standard (non-admin) macOS account without sudo, run these commands using an admin account:
+Or for a standard (non-admin) user, run:
 
-  sudo mkdir -p "${HOMEBREW_PREFIX}"
-  sudo chown -R "${USER}:${GROUP}" "${HOMEBREW_PREFIX}"
+sudo mkdir -p "${HOMEBREW_PREFIX}"
+sudo chown -R "${USER}:${GROUP}" "${HOMEBREW_PREFIX}"
 
-Then you can rerun this script entirely without admin privileges.
+Then run this installer script again.
 EOABORT
     )"
   fi


### PR DESCRIPTION
Allow macOS installation without sudo if prefix is user-writable

Previously, the installer always aborted if sudo was unavailable on macOS.

This change adds a check to determine if the Homebrew prefix is already writable by the current user.

If writable, the script proceeds without sudo.

Otherwise, it aborts with a clear message instructing users how to create and adjust permissions on the Homebrew prefix, enabling standard (non-admin) users to install Homebrew in that directory.

Developed and tested on 15.3.1