### PR TITLE
Add caching to CLT installation check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -352,18 +352,28 @@ check_run_command_as_root() {
 }
 
 should_install_command_line_tools() {
-  if [[ -n "${HOMEBREW_ON_LINUX-}" ]]
-  then
+  if [[ -n "${SHOULD_INSTALL_CLT-}" ]]; then
+    return "${SHOULD_INSTALL_CLT}"
+  fi
+
+  if [[ -n "${HOMEBREW_ON_LINUX-}" ]]; then
+    SHOULD_INSTALL_CLT=1
     return 1
   fi
 
-  if version_gt "${macos_version}" "10.13"
-  then
+  local ret
+
+  if version_gt "${macos_version}" "10.13"; then
     ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]]
+    ret=$?
   else
-    ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]] ||
+    ! [[ -e "/Library/Developer/CommandLineTools/usr/bin/git" ]] || \
       ! [[ -e "/usr/include/iconv.h" ]]
+    ret=$?
   fi
+
+  SHOULD_INSTALL_CLT=$ret
+  return "$ret"
 }
 
 get_permission() {


### PR DESCRIPTION
Improve the should_install_command_line_tools function by:
1. Caching the result in SHOULD_INSTALL_CLT to avoid redundant file existence checks.
2. Using a local variable (ret) to capture return values for added clarity.

This change slightly increases code size but provides a more efficient
and readable approach.

**Upsides:**
- Efficiency improvement by skipping redundant checks on subsequent calls.

**Downsides:**
- Introduces a new global variable (SHOULD_INSTALL_CLT).
- Increases the function length by about 10 lines.