### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -551,18 +551,9 @@ then
     abort "Homebrew is only supported on Intel and ARM processors!"
   fi
 else
-  # On Linux, support only 64-bit Intel
-  if [[ "${UNAME_MACHINE}" == "aarch64" ]]
+  if [[ "${UNAME_MACHINE}" != "x86_64" ]] && [[ "${UNAME_MACHINE}" != "aarch64" ]]
   then
-    abort "$(
-      cat <<EOABORT
-Homebrew on Linux is not supported on ARM processors.
-  ${tty_underline}https://docs.brew.sh/Homebrew-on-Linux#arm-unsupported${tty_reset}
-EOABORT
-    )"
-  elif [[ "${UNAME_MACHINE}" != "x86_64" ]]
-  then
-    abort "Homebrew on Linux is only supported on Intel processors!"
+    abort "Homebrew on Linux is only supported on Intel & ARM processors!"
   fi
 fi
 


### PR DESCRIPTION
With the current `install.sh` script, any attempt to install brew for Linux on `aarch64` machines will result in an error. This small fix removes the check and allows brew to be installed.

Tested on ubuntu 24.04 aarch64. I was also able to install various tools from Google (like grpc, protobuf, googletest and others).

It might not work well as it does for Intel x86, but it is better than the current alternative 

Hope this fix will go through !