### PR TITLE
Add Homebrew to PATH automatically if possible.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -973,7 +973,14 @@ ohai "Downloading and installing Homebrew..."
   execute "${HOMEBREW_PREFIX}/bin/brew" "update" "--force" "--quiet"
 ) || exit 1
 
-if [[ ":${PATH}:" != *":${HOMEBREW_PREFIX}/bin:"* ]]
+# create paths.d file for /opt/homebrew installs
+# (/usr/local/bin is already in the PATH)
+if [[ -d "/etc/paths.d" && "${HOMEBREW_PREFIX}" != "/usr/local" && -x "$(command -v tee)" ]]
+then
+  execute_sudo "${MKDIR[@]}" /etc/paths.d
+  echo "${HOMEBREW_PREFIX}/bin" | execute_sudo tee /etc/paths.d/homebrew
+  execute_sudo "${CHOWN[@]}" root:wheel /etc/paths.d/homebrew
+elif [[ ":${PATH}:" != *":${HOMEBREW_PREFIX}/bin:"* ]]
 then
   warn "${HOMEBREW_PREFIX}/bin is not in your PATH.
   Instructions on how to configure your shell for Homebrew

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -326,6 +326,7 @@ fi
   fi
   echo "${HOMEBREW_CELLAR}"
   echo "${HOMEBREW_PREFIX}/Caskroom"
+  echo "/etc/paths.d/homebrew"
 
   [[ -n ${opt_skip_cache_and_logs} ]] || cat <<-EOS
 ${HOME}/Library/Caches/Homebrew


### PR DESCRIPTION
This is automatic for `/usr/local/bin/brew` but let's do it manually for other prefixes too.

See also https://github.com/Homebrew/brew/pull/20159 and https://github.com/Homebrew/install/issues/986