### PR TITLE
install.sh: Improve portability

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,7 @@ else
   HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
   HOMEBREW_CACHE="${HOME}/.cache/Homebrew"
 
-  STAT_PRINTF=("/usr/bin/stat" "--printf")
+  STAT_PRINTF=("/usr/bin/stat" "-c")
   PERMISSION_FORMAT="%a"
   CHOWN=("/bin/chown")
   CHGRP=("/bin/chgrp")


### PR DESCRIPTION
Both coreutils stat and busybox stat support `-c`, but busybox stat does not support `--printf`.

After this modification, `install.sh` can run in an environment with busybox utils.