### PR TITLE
install.sh: improve POSIX compatibility

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -385,7 +385,9 @@ do
 done
 if [[ "${#paths[@]}" -gt 0 ]]
 then
-  args=("${paths[@]}" -type l -lname '*/Cellar/*')
+  # We want expand in subcommand, not here
+  # shellcheck disable=SC2016
+  args=("${paths[@]}" -type l -exec /bin/sh -c 'case $(ls -l "$1") in *-\>\ */Cellar/*)exit;esac;exit 1' _ {} \;)
   if [[ -n "${opt_dry_run}" ]]
   then
     args+=(-print)


### PR DESCRIPTION
POSIX `find` do not support `-lname`: <https://pubs.opengroup.org/onlinepubs/9799919799/utilities/find.html>

The purpose of this #PR is the same as #1010, which is to use the busybox toolchain to run the script.

It seems a bit too complicated and reduces readability. Feel free to close this PR.