### PR TITLE
install.sh: don't create $HOMEBREW_CACHE with sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -813,12 +813,7 @@ execute_sudo "${CHOWN[@]}" "-R" "${USER}:${GROUP}" "${HOMEBREW_REPOSITORY}"
 
 if ! [[ -d "${HOMEBREW_CACHE}" ]]
 then
-  if [[ -n "${HOMEBREW_ON_MACOS-}" ]]
-  then
-    execute_sudo "${MKDIR[@]}" "${HOMEBREW_CACHE}"
-  else
-    execute "${MKDIR[@]}" "${HOMEBREW_CACHE}"
-  fi
+  execute "${MKDIR[@]}" "${HOMEBREW_CACHE}"
 fi
 if exists_but_not_writable "${HOMEBREW_CACHE}"
 then


### PR DESCRIPTION
This is #286 but applied to macOS too. I believe that the same reasons apply: if in some rare cases `~/Library/Caches` or even `~/Library` doesn't exist, we don't want to create it with sudo permissions because it will then be owned by root.

Fixes #1024.
