### PR TITLE
install.sh: do not echo newline to `shell_rcfile`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1108,7 +1108,6 @@ EOS
 else
   cat <<EOS
 - Run these commands in your terminal to add Homebrew to your ${tty_bold}PATH${tty_reset}:
-    echo >> ${shell_rcfile}
     echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_rcfile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
 EOS


### PR DESCRIPTION
The initial installation should be as simple as possible. The newline is nice but it is 1/3rd of what the user has to do after the install.

If we want to keep it I suggest swapping the echo to printf and using `\n`.