### PR TITLE
install.sh: print correct dnf group name on non-Fedora distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1147,7 +1147,15 @@ then
     echo "    sudo apt-get install build-essential"
   elif [[ -x "$(command -v dnf)" ]]
   then
-    echo "    sudo dnf group install development-tools"
+    # Fedora uses the lowercase `development-tools` group id; most other
+    # dnf-based distros use the `Development Tools` name instead.
+    # shellcheck disable=SC1091
+    if [[ -r /etc/os-release ]] && (. /etc/os-release && [[ "${ID:-}" == "fedora" ]])
+    then
+      echo "    sudo dnf group install development-tools"
+    else
+      echo "    sudo dnf group install 'Development Tools'"
+    fi
   elif [[ -x "$(command -v yum)" ]]
   then
     echo "    sudo yum groupinstall 'Development Tools'"


### PR DESCRIPTION
On an Amazon Linux 2023 instance, I got this output from the Homebrew installer:

```
- Install Homebrew's dependencies if you have sudo access:
    sudo dnf group install development-tools
```

But that command failed:

```sh
$ sudo dnf group install development-tools
Amazon Linux 2023 Internal Shared Repository                                                          20 kB/s | 863  B     00:00
Module or Group 'development-tools' is not available.
Error: Nothing to do.
```

The [Homebrew on Linux docs](https://docs.brew.sh/Homebrew-on-Linux) acknowledge this issue: They say that you should run `sudo dnf group install development-tools` under Fedora, but `sudo dnf group install 'Development Tools'` under CentOS Stream or RHEL. (Amazon Linux 2023 follows the CentOS/RHEL convention.) The installer, however, prints the `development-tools` command whenever `dnf` exists.

The fix here is to check `/etc/os-release` for `id=fedora`. If that file indicates that this is a Fedora system, print the `development-tools` command; otherwise, print the `Development Tools` command.