### PR TITLE
install.sh/ring_bell: make the function more concise

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -323,10 +323,7 @@ getc() {
 
 ring_bell() {
   # Use the shell's audible bell.
-  if [[ -t 1 ]]
-  then
-    printf "\a"
-  fi
+  [[ -t 1 ]] && printf "\a"
 }
 
 wait_for_user() {


### PR DESCRIPTION
This style is used elsewhere:
https://github.com/Homebrew/install/blob/280cbc9adffcbdef15dd1c9d991ef2d1dd7cfc9c/install.sh#L351

It makes the code more readable