### PR TITLE
Remove the prompt for `brew install gcc` after installing Homebrew on Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1165,8 +1165,6 @@ then
   cat <<EOS
   For more information, see:
     ${tty_underline}https://docs.brew.sh/Homebrew-on-Linux${tty_reset}
-- We recommend that you install GCC:
-    brew install gcc
 EOS
 fi
 


### PR DESCRIPTION
- Fixes https://github.com/orgs/Homebrew/discussions/6676 .
- Remove the prompt for `brew install gcc` after installing Homebrew on Linux.
- This is a recap of https://github.com/Homebrew/install/pull/270 . The reason why https://github.com/orgs/Homebrew/discussions/6676 requires installing `brew install gcc` is because of https://github.com/Linuxbrew/homebrew-science/issues/257, which has been fixed by https://github.com/Linuxbrew/homebrew-science/issues/257, which is now a 404 error.
- However, this command still seems strange on Linux because most people who use Homebrew don't know how to use Sambamba at all, so requiring all Linux users to execute `brew install gcc` is meaningless. Furthermore, if this is a bug in Sambamba, then I think the Sambamba brew package should proactively prompt the user, rather than prompting the user in the Homebrew installation script.