### PR TITLE
install.sh: use Development Tools group on Amazon Linux 2023

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1144,8 +1144,11 @@ then
   then
     # Fedora and RHEL-like distros use the lowercase `development-tools`
     # group id; most other dnf-based distros use the `Development Tools` name instead.
+    # Amazon Linux 2023 sets ID_LIKE=fedora but only ships `Development Tools`
+    # (group id: development); `development-tools` does not exist there.
     # shellcheck disable=SC1091
     if [[ -r /etc/os-release ]] && (. /etc/os-release &&
+       [[ "${ID:-}" != "amzn" ]] &&
        [[ "${ID:-}" == *fedora* || "${ID:-}" == *rhel* ||
           "${ID_LIKE:-}" == *fedora* || "${ID_LIKE:-}" == *rhel* ]])
     then


### PR DESCRIPTION
## Summary
- Amazon Linux 2023 sets `ID=amzn` and `ID_LIKE=fedora`, so the post-install dependency hint currently recommends `sudo dnf group install development-tools`.
- On AL2023 that group id does not exist (`Module or Group 'development-tools' is not available`). The available group is `Development Tools` (group id: `development`).
- Exclude `ID=amzn` from the Fedora/RHEL `development-tools` branch so AL2023 gets `sudo dnf group install 'Development Tools'`.

## Questions

Should I add a `Dockerfile` test case or something?  Feedback requested. :)